### PR TITLE
Chore/system fix/devin (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ uvicorn app.main:app --reload
 The API is available at `http://localhost:8000`, with interactive documentation at
 `http://localhost:8000/docs`. Use `GET /health` to check the API process,
 `GET /ready` to check database/RAG data readiness, and `POST /chat` to submit a
-message to the RAG pipeline.
+message to the RAG pipeline. Use `GET /status` to inspect readiness plus latest
+pipeline run metadata without changing readiness semantics.
 
 ---
 

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from app.api.deps import get_rag_orchestrator
 from app.schemas.search_result import SearchResult
 from app.services.readiness import check_readiness
+from app.services.system_status import get_system_status
 from app.services.rag.orchestrator import RAGOrchestrator
 
 
@@ -50,6 +51,11 @@ def ready() -> JSONResponse:
         status_code=200 if readiness.is_ready else 503,
         content=readiness.to_dict(),
     )
+
+
+@app.get("/status", tags=["system"])
+def status() -> dict:
+    return get_system_status().to_dict()
 
 
 @app.post("/chat", response_model=ChatResponse, tags=["chat"])

--- a/app/services/system_status.py
+++ b/app/services/system_status.py
@@ -1,0 +1,132 @@
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg2
+
+from app.core.config import settings
+from app.services.readiness import ReadinessCheck, check_readiness
+
+
+@dataclass(frozen=True)
+class LatestPipelineRun:
+    pipeline_name: str
+    status: str
+    started_at: str | None
+    finished_at: str | None
+    report_path: str | None
+    error_type: str | None
+    error_message: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pipeline_name": self.pipeline_name,
+            "status": self.status,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "report_path": self.report_path,
+            "error_type": self.error_type,
+            "error_message": self.error_message,
+        }
+
+
+@dataclass(frozen=True)
+class PipelineMetadataStatus:
+    latest_run: LatestPipelineRun | None
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "available": self.reason is None,
+            "latest_run": (
+                self.latest_run.to_dict() if self.latest_run else None
+            ),
+            **({"reason": self.reason} if self.reason else {}),
+        }
+
+
+@dataclass(frozen=True)
+class SystemStatus:
+    api: str
+    rag_ready: bool
+    readiness: ReadinessCheck
+    pipeline_metadata: PipelineMetadataStatus
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "api": self.api,
+            "rag_ready": self.rag_ready,
+            "readiness": self.readiness.to_dict(),
+            "pipeline_metadata": self.pipeline_metadata.to_dict(),
+        }
+
+
+def get_system_status(
+    database_url: str | None = None,
+) -> SystemStatus:
+    readiness = check_readiness(database_url)
+    return SystemStatus(
+        api="ok",
+        rag_ready=readiness.is_ready,
+        readiness=readiness,
+        pipeline_metadata=get_pipeline_metadata_status(database_url),
+    )
+
+
+def get_pipeline_metadata_status(
+    database_url: str | None = None,
+    *,
+    pipeline_name: str = "wechat",
+) -> PipelineMetadataStatus:
+    database_url = database_url or settings.DATABASE_URL
+    if not database_url:
+        return PipelineMetadataStatus(
+            latest_run=None,
+            reason="DATABASE_URL is not configured",
+        )
+
+    try:
+        with psycopg2.connect(database_url) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT to_regclass('pipeline_runs');
+                    """
+                )
+                if cursor.fetchone()[0] is None:
+                    return PipelineMetadataStatus(
+                        latest_run=None,
+                        reason="pipeline_runs table does not exist",
+                    )
+
+                cursor.execute(
+                    """
+                    SELECT pipeline_name, status, started_at, finished_at,
+                           report_path, error_type, error_message
+                    FROM pipeline_runs
+                    WHERE pipeline_name = %s
+                    ORDER BY started_at DESC
+                    LIMIT 1;
+                    """,
+                    (pipeline_name,),
+                )
+                row = cursor.fetchone()
+    except Exception as error:
+        return PipelineMetadataStatus(
+            latest_run=None,
+            reason=str(error),
+        )
+
+    if row is None:
+        return PipelineMetadataStatus(latest_run=None)
+
+    return PipelineMetadataStatus(
+        latest_run=LatestPipelineRun(
+            pipeline_name=row[0],
+            status=row[1],
+            started_at=row[2].isoformat() if row[2] else None,
+            finished_at=row[3].isoformat() if row[3] else None,
+            report_path=row[4],
+            error_type=row[5],
+            error_message=row[6],
+        )
+    )

--- a/docker-command.md
+++ b/docker-command.md
@@ -20,6 +20,8 @@ docker compose --profile gpu up --build
 Open:
 
 - API health: <http://localhost:8000/health>
+- API readiness: <http://localhost:8000/ready>
+- API/data status: <http://localhost:8000/status>
 - Interactive API docs: <http://localhost:8000/docs>
 
 The `cpu` and `gpu` profiles run the `migrate-cpu` service before starting the

--- a/migrations/versions/20260713_0004_create_pipeline_runs.py
+++ b/migrations/versions/20260713_0004_create_pipeline_runs.py
@@ -1,0 +1,58 @@
+"""create pipeline_runs table
+
+Revision ID: 20260713_0004
+Revises: 20260705_0003
+Create Date: 2026-07-13
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "20260713_0004"
+down_revision = "20260705_0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pipeline_runs",
+        sa.Column("id", sa.Text(), primary_key=True),
+        sa.Column("pipeline_name", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("input_path", sa.Text(), nullable=True),
+        sa.Column("output_path", sa.Text(), nullable=True),
+        sa.Column("report_path", sa.Text(), nullable=True),
+        sa.Column("record_count", sa.Integer(), nullable=True),
+        sa.Column("affected_count", sa.Integer(), nullable=True),
+        sa.Column("error_type", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "pipeline_runs_pipeline_started_idx",
+        "pipeline_runs",
+        ["pipeline_name", "started_at"],
+    )
+    op.create_index(
+        "pipeline_runs_status_idx",
+        "pipeline_runs",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("pipeline_runs_status_idx", table_name="pipeline_runs")
+    op.drop_index(
+        "pipeline_runs_pipeline_started_idx",
+        table_name="pipeline_runs",
+    )
+    op.drop_table("pipeline_runs")

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -72,6 +72,11 @@ Reports include the run status, start/end timestamps, source/output paths,
 record counts and failure details when a stage raises an error. They are local
 audit files today and map cleanly to future object-storage reports.
 
+PostgreSQL also has a `pipeline_runs` table for durable run metadata. This table
+is managed by Alembic and stores run status, data freshness signals and report
+locations. The complete WeChat pipeline writes `started`, `completed` and
+`failed` status transitions when run through the CLI with `DATABASE_URL`.
+
 ## Complete local workflow
 
 To run harvesting, transformation, validation, embedding and import as one

--- a/pipelines/cli.py
+++ b/pipelines/cli.py
@@ -183,6 +183,9 @@ def _run_command(
             },
         )
     elif args.command == "run-wechat-pipeline":
+        from pipelines.loaders.postgres_pipeline_runs import (
+            PostgresPipelineRunLoader,
+        )
         from pipelines.orchestration.wechat_pipeline import (
             run_local_wechat_pipeline,
         )
@@ -196,6 +199,9 @@ def _run_command(
             database_url=args.database_url,
             batch_size=args.batch_size,
             reset_import_checkpoint=args.reset_import_checkpoint,
+            pipeline_run_loader=PostgresPipelineRunLoader(
+                args.database_url
+            ),
             run_id=run_id,
         )
         logger.info(

--- a/pipelines/loaders/postgres_pipeline_runs.py
+++ b/pipelines/loaders/postgres_pipeline_runs.py
@@ -1,0 +1,119 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+import psycopg2
+
+
+VALID_PIPELINE_RUN_STATUSES = {"started", "completed", "failed"}
+
+
+@dataclass(frozen=True)
+class PipelineRunRecord:
+    id: str
+    pipeline_name: str
+    status: str
+    started_at: datetime
+    finished_at: datetime | None = None
+    input_path: str | None = None
+    output_path: str | None = None
+    report_path: str | None = None
+    record_count: int | None = None
+    affected_count: int | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+class PostgresPipelineRunLoader:
+    def __init__(
+        self,
+        database_url: str,
+        table_name: str = "pipeline_runs",
+    ):
+        if not database_url:
+            raise ValueError("database_url is required")
+        if table_name != "pipeline_runs":
+            raise ValueError("only pipeline_runs table is supported")
+        self.database_url = database_url
+        self.table_name = table_name
+
+    def upsert_run(self, record: PipelineRunRecord) -> int:
+        _validate_record(record)
+        with psycopg2.connect(self.database_url) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO pipeline_runs (
+                        id,
+                        pipeline_name,
+                        status,
+                        started_at,
+                        finished_at,
+                        input_path,
+                        output_path,
+                        report_path,
+                        record_count,
+                        affected_count,
+                        error_type,
+                        error_message
+                    )
+                    VALUES (
+                        %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT (id) DO UPDATE SET
+                        pipeline_name = EXCLUDED.pipeline_name,
+                        status = EXCLUDED.status,
+                        started_at = EXCLUDED.started_at,
+                        finished_at = EXCLUDED.finished_at,
+                        input_path = EXCLUDED.input_path,
+                        output_path = EXCLUDED.output_path,
+                        report_path = EXCLUDED.report_path,
+                        record_count = EXCLUDED.record_count,
+                        affected_count = EXCLUDED.affected_count,
+                        error_type = EXCLUDED.error_type,
+                        error_message = EXCLUDED.error_message
+                    """,
+                    _record_to_row(record),
+                )
+                affected = cursor.rowcount
+            connection.commit()
+        return affected
+
+
+def upsert_pipeline_run(
+    database_url: str,
+    record: PipelineRunRecord,
+) -> int:
+    return PostgresPipelineRunLoader(database_url).upsert_run(record)
+
+
+def _validate_record(record: PipelineRunRecord) -> None:
+    if not record.id.strip():
+        raise ValueError("pipeline run id cannot be empty")
+    if not record.pipeline_name.strip():
+        raise ValueError("pipeline_name cannot be empty")
+    if record.status not in VALID_PIPELINE_RUN_STATUSES:
+        valid_statuses = ", ".join(sorted(VALID_PIPELINE_RUN_STATUSES))
+        raise ValueError(f"status must be one of: {valid_statuses}")
+    if (
+        record.finished_at is not None
+        and record.finished_at < record.started_at
+    ):
+        raise ValueError("finished_at cannot be before started_at")
+
+
+def _record_to_row(record: PipelineRunRecord) -> tuple:
+    return (
+        record.id,
+        record.pipeline_name,
+        record.status,
+        record.started_at,
+        record.finished_at,
+        record.input_path,
+        record.output_path,
+        record.report_path,
+        record.record_count,
+        record.affected_count,
+        record.error_type,
+        record.error_message,
+    )

--- a/pipelines/orchestration/wechat_pipeline.py
+++ b/pipelines/orchestration/wechat_pipeline.py
@@ -4,10 +4,11 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 from uuid import uuid4
 
 from pipelines.ingestion.wechat import WechatHarvesterConfig
+from pipelines.loaders.postgres_pipeline_runs import PipelineRunRecord
 from pipelines.orchestration.harvest_wechat import run_local_harvest
 from pipelines.orchestration.import_knowledge_base import run_local_import
 from pipelines.orchestration.transform_wechat import run_local_transform
@@ -21,6 +22,10 @@ from pipelines.shared.reports import write_json_report
 
 
 logger = logging.getLogger(__name__)
+
+
+class PipelineRunMetadataLoader(Protocol):
+    def upsert_run(self, record: PipelineRunRecord) -> int: ...
 
 
 @dataclass(frozen=True)
@@ -53,6 +58,7 @@ def run_local_wechat_pipeline(
     batch_size: int = 100,
     import_checkpoint_file: Path | None = None,
     reset_import_checkpoint: bool = False,
+    pipeline_run_loader: PipelineRunMetadataLoader | None = None,
     run_id: str | None = None,
 ) -> WechatPipelineRunResult:
     run_id = run_id or str(uuid4())
@@ -77,6 +83,16 @@ def run_local_wechat_pipeline(
         logger.info(
             "WeChat pipeline started",
             extra={"event": "pipeline_started"},
+        )
+        _upsert_pipeline_run_metadata(
+            pipeline_run_loader,
+            PipelineRunRecord(
+                id=run_id,
+                pipeline_name="wechat",
+                status="started",
+                started_at=run_started_at,
+                input_path=str(raw_output_file),
+            ),
         )
 
         try:
@@ -122,13 +138,29 @@ def run_local_wechat_pipeline(
                 },
             )
         except Exception as error:
-            _write_wechat_pipeline_report(
+            finished_at = datetime.now(timezone.utc)
+            report_file = _write_wechat_pipeline_report(
                 data_dir=data_dir,
                 run_id=run_id,
                 status="failed",
                 started_at=run_started_at,
-                finished_at=datetime.now(timezone.utc),
+                finished_at=finished_at,
                 error=error,
+            )
+            _upsert_pipeline_run_metadata(
+                pipeline_run_loader,
+                PipelineRunRecord(
+                    id=run_id,
+                    pipeline_name="wechat",
+                    status="failed",
+                    started_at=run_started_at,
+                    finished_at=finished_at,
+                    input_path=str(raw_output_file),
+                    output_path=str(processed_output_file),
+                    report_path=str(report_file),
+                    error_type=type(error).__name__,
+                    error_message=str(error),
+                ),
             )
             raise
 
@@ -143,15 +175,31 @@ def run_local_wechat_pipeline(
             raw_output_location=harvest_result.output_location,
             processed_output_file=processed_output_file,
         )
+        finished_at = datetime.now(timezone.utc)
         report_file = _write_wechat_pipeline_report(
             data_dir=data_dir,
             run_id=run_id,
             status="completed",
             started_at=run_started_at,
-            finished_at=datetime.now(timezone.utc),
+            finished_at=finished_at,
             result=result,
         )
         result = replace(result, report_file=report_file)
+        _upsert_pipeline_run_metadata(
+            pipeline_run_loader,
+            PipelineRunRecord(
+                id=run_id,
+                pipeline_name="wechat",
+                status="completed",
+                started_at=run_started_at,
+                finished_at=finished_at,
+                input_path=str(raw_output_file),
+                output_path=str(processed_output_file),
+                report_path=str(report_file),
+                record_count=result.transformed_count,
+                affected_count=result.affected_count,
+            ),
+        )
         logger.info(
             "WeChat pipeline completed",
             extra={
@@ -165,6 +213,15 @@ def run_local_wechat_pipeline(
             },
         )
         return result
+
+
+def _upsert_pipeline_run_metadata(
+    loader: PipelineRunMetadataLoader | None,
+    record: PipelineRunRecord,
+) -> None:
+    if loader is None:
+        return
+    loader.upsert_run(record)
 
 
 def _pipeline_reports_dir(data_dir: Path) -> Path:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,4 +34,5 @@ def clean_knowledge_base(test_database_url, migrated_test_database):
     with psycopg2.connect(test_database_url) as conn:
         with conn.cursor() as cur:
             cur.execute("DELETE FROM knowledge_base;")
+            cur.execute("DELETE FROM pipeline_runs;")
         conn.commit()

--- a/tests/integration/test_postgres_pipeline_runs.py
+++ b/tests/integration/test_postgres_pipeline_runs.py
@@ -1,0 +1,70 @@
+import os
+from datetime import datetime, timezone
+
+import psycopg2
+import pytest
+
+from pipelines.loaders.postgres_pipeline_runs import (
+    PipelineRunRecord,
+    upsert_pipeline_run,
+)
+
+
+pytestmark = pytest.mark.integration
+
+if os.getenv("RUN_INTEGRATION_TESTS") != "1":
+    pytest.skip("skip integration tests by default", allow_module_level=True)
+
+
+def test_pipeline_run_can_be_inserted_and_updated(test_database_url):
+    started_at = datetime(2026, 7, 13, tzinfo=timezone.utc)
+
+    first_affected = upsert_pipeline_run(
+        test_database_url,
+        PipelineRunRecord(
+            id="run-123",
+            pipeline_name="wechat",
+            status="started",
+            started_at=started_at,
+            input_path="data/current/wechat_articles_all.json",
+        ),
+    )
+    second_affected = upsert_pipeline_run(
+        test_database_url,
+        PipelineRunRecord(
+            id="run-123",
+            pipeline_name="wechat",
+            status="completed",
+            started_at=started_at,
+            finished_at=datetime(2026, 7, 13, 1, tzinfo=timezone.utc),
+            input_path="data/current/wechat_articles_all.json",
+            output_path="data/current/wechat_articles_processed.json",
+            report_path=(
+                "data/reports/pipelines/wechat_pipeline_run-123.json"
+            ),
+            record_count=9,
+            affected_count=8,
+        ),
+    )
+
+    with psycopg2.connect(test_database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT status, output_path, report_path, record_count,
+                       affected_count
+                FROM pipeline_runs
+                WHERE id = 'run-123';
+                """
+            )
+            stored = cursor.fetchone()
+
+    assert first_affected == 1
+    assert second_affected == 1
+    assert stored == (
+        "completed",
+        "data/current/wechat_articles_processed.json",
+        "data/reports/pipelines/wechat_pipeline_run-123.json",
+        9,
+        8,
+    )

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -5,6 +5,10 @@ from app.main import app
 from app.schemas.article import Article
 from app.schemas.search_result import SearchResult
 from app.services.readiness import ReadinessCheck
+from app.services.system_status import (
+    PipelineMetadataStatus,
+    SystemStatus,
+)
 
 
 class StubOrchestrator:
@@ -80,6 +84,37 @@ def test_ready_returns_503_when_database_or_data_are_not_ready(monkeypatch):
     assert response.status_code == 503
     assert response.json()["status"] == "not_ready"
     assert response.json()["reason"] == "knowledge_base has no rows"
+
+
+def test_status_reports_readiness_and_pipeline_metadata(monkeypatch):
+    monkeypatch.setattr(
+        "app.main.get_system_status",
+        lambda: SystemStatus(
+            api="ok",
+            rag_ready=True,
+            readiness=ReadinessCheck(
+                status="ready",
+                database="ok",
+                knowledge_base_rows=3,
+                embedding_model="test-model",
+                embedding_revision="revision-123",
+            ),
+            pipeline_metadata=PipelineMetadataStatus(
+                latest_run=None,
+            ),
+        ),
+    )
+
+    response = client().get("/status")
+
+    assert response.status_code == 200
+    assert response.json()["api"] == "ok"
+    assert response.json()["rag_ready"] is True
+    assert response.json()["readiness"]["status"] == "ready"
+    assert response.json()["pipeline_metadata"] == {
+        "available": True,
+        "latest_run": None,
+    }
 
 
 def test_chat_returns_answer_and_sources():

--- a/tests/unit/test_pipeline_cli.py
+++ b/tests/unit/test_pipeline_cli.py
@@ -83,7 +83,11 @@ def test_import_knowledge_base_command(mock_run_local_import):
 @patch(
     "pipelines.orchestration.wechat_pipeline.run_local_wechat_pipeline"
 )
-def test_run_wechat_pipeline_command(mock_run_pipeline):
+@patch("pipelines.loaders.postgres_pipeline_runs.PostgresPipelineRunLoader")
+def test_run_wechat_pipeline_command(
+    mock_pipeline_run_loader_class,
+    mock_run_pipeline,
+):
     mock_run_pipeline.return_value = WechatPipelineRunResult(
         run_id="run-123",
         harvested_count=12,
@@ -108,11 +112,17 @@ def test_run_wechat_pipeline_command(mock_run_pipeline):
     )
 
     assert exit_code == 0
+    mock_pipeline_run_loader_class.assert_called_once_with(
+        "postgresql://test:test@localhost:5432/testdb"
+    )
     mock_run_pipeline.assert_called_once_with(
         database_url=(
             "postgresql://test:test@localhost:5432/testdb"
         ),
         batch_size=100,
         reset_import_checkpoint=True,
+        pipeline_run_loader=(
+            mock_pipeline_run_loader_class.return_value
+        ),
         run_id=ANY,
     )

--- a/tests/unit/test_postgres_pipeline_runs.py
+++ b/tests/unit/test_postgres_pipeline_runs.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pipelines.loaders.postgres_pipeline_runs import (
+    PipelineRunRecord,
+    PostgresPipelineRunLoader,
+)
+
+
+DATABASE_URL = "postgresql://test:test@localhost:5432/testdb"
+
+
+def _record(status: str = "started") -> PipelineRunRecord:
+    return PipelineRunRecord(
+        id="run-123",
+        pipeline_name="wechat",
+        status=status,
+        started_at=datetime(2026, 7, 13, tzinfo=timezone.utc),
+    )
+
+
+def test_loader_requires_database_url():
+    with pytest.raises(ValueError, match="database_url is required"):
+        PostgresPipelineRunLoader("")
+
+
+def test_loader_rejects_unknown_status():
+    loader = PostgresPipelineRunLoader(DATABASE_URL)
+
+    with pytest.raises(ValueError, match="status must be one of"):
+        loader.upsert_run(_record("unknown"))
+
+
+def test_loader_rejects_finished_before_started():
+    loader = PostgresPipelineRunLoader(DATABASE_URL)
+    record = PipelineRunRecord(
+        id="run-123",
+        pipeline_name="wechat",
+        status="completed",
+        started_at=datetime(2026, 7, 13, 2, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 7, 13, 1, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="finished_at cannot be before started_at",
+    ):
+        loader.upsert_run(record)
+
+
+@patch("pipelines.loaders.postgres_pipeline_runs.psycopg2.connect")
+def test_loader_upserts_pipeline_run(mock_connect):
+    connection = MagicMock()
+    cursor = MagicMock()
+    cursor.rowcount = 1
+    connection.__enter__.return_value = connection
+    connection.cursor.return_value.__enter__.return_value = cursor
+    mock_connect.return_value = connection
+    loader = PostgresPipelineRunLoader(DATABASE_URL)
+
+    affected = loader.upsert_run(
+        PipelineRunRecord(
+            id="run-123",
+            pipeline_name="wechat",
+            status="completed",
+            started_at=datetime(2026, 7, 13, tzinfo=timezone.utc),
+            finished_at=datetime(2026, 7, 13, 1, tzinfo=timezone.utc),
+            input_path="data/current/wechat_articles_all.json",
+            output_path="data/current/wechat_articles_processed.json",
+            report_path="data/reports/pipelines/wechat_pipeline_run-123.json",
+            record_count=9,
+            affected_count=8,
+        )
+    )
+
+    assert affected == 1
+    mock_connect.assert_called_once_with(DATABASE_URL)
+    cursor.execute.assert_called_once()
+    assert "ON CONFLICT (id) DO UPDATE" in cursor.execute.call_args.args[0]
+    connection.commit.assert_called_once()

--- a/tests/unit/test_system_status.py
+++ b/tests/unit/test_system_status.py
@@ -1,0 +1,121 @@
+from datetime import datetime, timezone
+
+from app.services import system_status
+
+
+class FakeCursor:
+    def __init__(self, fetch_values):
+        self.fetch_values = list(fetch_values)
+        self.executed = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchone(self):
+        return self.fetch_values.pop(0)
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_pipeline_metadata_reports_latest_run(monkeypatch):
+    cursor = FakeCursor(
+        [
+            ("pipeline_runs",),
+            (
+                "wechat",
+                "failed",
+                datetime(2026, 7, 14, 1, tzinfo=timezone.utc),
+                datetime(2026, 7, 14, 2, tzinfo=timezone.utc),
+                "data/reports/pipelines/wechat_pipeline_run-123.json",
+                "ValueError",
+                "invalid raw data",
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        system_status.psycopg2,
+        "connect",
+        lambda database_url: FakeConnection(cursor),
+    )
+
+    status = system_status.get_pipeline_metadata_status(
+        "postgresql://test"
+    )
+
+    assert status.reason is None
+    assert status.latest_run is not None
+    assert status.latest_run.status == "failed"
+    assert status.latest_run.error_type == "ValueError"
+    assert status.to_dict()["available"] is True
+
+
+def test_pipeline_metadata_handles_missing_table(monkeypatch):
+    cursor = FakeCursor([(None,)])
+    monkeypatch.setattr(
+        system_status.psycopg2,
+        "connect",
+        lambda database_url: FakeConnection(cursor),
+    )
+
+    status = system_status.get_pipeline_metadata_status(
+        "postgresql://test"
+    )
+
+    assert status.latest_run is None
+    assert status.reason == "pipeline_runs table does not exist"
+
+
+def test_system_status_keeps_rag_readiness_separate_from_pipeline(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        system_status,
+        "check_readiness",
+        lambda database_url=None: system_status.ReadinessCheck(
+            status="ready",
+            database="ok",
+            knowledge_base_rows=10,
+            embedding_model="test-model",
+            embedding_revision="revision-123",
+        ),
+    )
+    monkeypatch.setattr(
+        system_status,
+        "get_pipeline_metadata_status",
+        lambda database_url=None: system_status.PipelineMetadataStatus(
+            latest_run=system_status.LatestPipelineRun(
+                pipeline_name="wechat",
+                status="failed",
+                started_at="2026-07-14T01:00:00+00:00",
+                finished_at="2026-07-14T02:00:00+00:00",
+                report_path="report.json",
+                error_type="ValueError",
+                error_message="invalid raw data",
+            )
+        ),
+    )
+
+    status = system_status.get_system_status("postgresql://test")
+    payload = status.to_dict()
+
+    assert payload["rag_ready"] is True
+    assert payload["readiness"]["status"] == "ready"
+    assert payload["pipeline_metadata"]["latest_run"]["status"] == "failed"

--- a/tests/unit/test_wechat_pipeline.py
+++ b/tests/unit/test_wechat_pipeline.py
@@ -2,7 +2,7 @@ import json
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -40,6 +40,7 @@ def test_local_pipeline_runs_stages_and_returns_report():
     if data_dir.exists():
         shutil.rmtree(data_dir)
     data_dir.mkdir()
+    metadata_loader = MagicMock()
 
     try:
         with (
@@ -83,6 +84,7 @@ def test_local_pipeline_runs_stages_and_returns_report():
                 result = run_local_wechat_pipeline(
                     DATABASE_URL,
                     data_dir=data_dir,
+                    pipeline_run_loader=metadata_loader,
                     run_id="run-123",
                 )
     finally:
@@ -113,6 +115,22 @@ def test_local_pipeline_runs_stages_and_returns_report():
     assert report_payload["transformed_count"] == 9
     assert report_payload["affected_count"] == 8
     assert report_payload["raw_output_location"] == raw_output_location
+    assert [
+        call.args[0].status
+        for call in metadata_loader.upsert_run.call_args_list
+    ] == ["started", "completed"]
+    completed_metadata = metadata_loader.upsert_run.call_args_list[1].args[0]
+    assert completed_metadata.id == "run-123"
+    assert completed_metadata.pipeline_name == "wechat"
+    assert completed_metadata.input_path == str(
+        data_dir / "current" / "wechat_articles_all.json"
+    )
+    assert completed_metadata.output_path == str(
+        data_dir / "current" / "wechat_articles_processed.json"
+    )
+    assert completed_metadata.report_path == str(expected_report_file)
+    assert completed_metadata.record_count == 9
+    assert completed_metadata.affected_count == 8
 
     assert result == WechatPipelineRunResult(
         run_id="run-123",
@@ -169,6 +187,7 @@ def test_local_pipeline_writes_failure_report():
     if data_dir.exists():
         shutil.rmtree(data_dir)
     data_dir.mkdir()
+    metadata_loader = MagicMock()
 
     try:
         with (
@@ -196,6 +215,7 @@ def test_local_pipeline_writes_failure_report():
             run_local_wechat_pipeline(
                 DATABASE_URL,
                 data_dir=data_dir,
+                pipeline_run_loader=metadata_loader,
                 run_id="run-failure",
             )
 
@@ -214,6 +234,17 @@ def test_local_pipeline_writes_failure_report():
     assert report_payload["status"] == "failed"
     assert report_payload["error_type"] == "ValueError"
     assert report_payload["error_message"] == "invalid raw data"
+    assert [
+        call.args[0].status
+        for call in metadata_loader.upsert_run.call_args_list
+    ] == ["started", "failed"]
+    failed_metadata = metadata_loader.upsert_run.call_args_list[1].args[0]
+    assert failed_metadata.id == "run-failure"
+    assert failed_metadata.error_type == "ValueError"
+    assert failed_metadata.error_message == "invalid raw data"
+    assert failed_metadata.report_path.endswith(
+        "wechat_pipeline_run-failure.json"
+    )
     import_records.assert_not_called()
     assert (
         pipeline_logger.exception.call_args.kwargs["extra"]["stage"]


### PR DESCRIPTION
* Make knowledge base imports refresh changed rows

* modified upsert output

* Create test_wechat_import_retrieval_pipeline.py

* Rename knowledge base loader methods to load

* switched to pgvector compatible system, made faiss legacy only

* Add Docker migration bootstrap flow

* Make /chat safer when the database is empty.

* Add API readiness endpoint

* added database ops scripts

* Add runtime config check command

* Add CI runtime config validation

* Add local stack rehearsal and versioned pipeline data outputs

* removed faiss dependency files

* Add production-style pipeline data layout and reports

* Add pipeline run metadata and status endpoint