### PR TITLE
feat(storage): pluggable storage abstraction for pipeline artifacts

### DIFF
--- a/docs/design/storage-abstraction.md
+++ b/docs/design/storage-abstraction.md
@@ -24,8 +24,8 @@
   - [Step 1:接口 + LocalStorage(已完成)](#step-1接口--localstorage已完成)
   - [Step 2:迁移 reports(已完成)](#step-2迁移-reports已完成)
   - [Step 3:迁移 wechat harvest checkpoint(已完成)](#step-3迁移-wechat-harvest-checkpoint已完成)
-  - [Step 4:迁移 article sink(待做)](#step-4迁移-article-sink待做)
-  - [Step 5:入口串联 + B 类咽喉点(待做)](#step-5入口串联--b-类咽喉点待做)
+  - [Step 4:迁移 article sink(已完成)](#step-4迁移-article-sink已完成)
+  - [Step 5:入口串联 + B 类咽喉点(已完成)](#step-5入口串联--b-类咽喉点已完成)
   - [Step 6:S3Storage(待做,Phase 3)](#step-6s3storage待做phase-3)
 - [迁移顺序原则:A 类先、B 类后](#迁移顺序原则a-类先b-类后)
 - [测试策略](#测试策略)
@@ -239,7 +239,7 @@ import 各段;stage 代码不再自己构造 storage、不再处理裸 `Path`。
 ## 迁移步骤
 
 咽喉点(现在直接碰文件系统的地方)逐个迁移,**每步单独提交、单独验证**。当前全套件
-共 **178 个单元测试**,每步都要求全绿。
+共 **186 个单元测试**,每步都要求全绿。
 
 ### Step 1:接口 + LocalStorage(已完成)
 
@@ -276,27 +276,46 @@ import 各段;stage 代码不再自己构造 storage、不再处理裸 `Path`。
 `LocalStorage(data_dir)` + key `checkpoints/wechat_scraper_state.json`。字节与位置不变;
 同步更新了直接测试它的 round-trip 用例。
 
-### Step 4:迁移 article sink(待做)
+### Step 4:迁移 article sink(已完成)
 
 > 前置基础:[三、Storage 接口(全部 6 个动作)](#三storage-接口与后端)。
 
 [JsonChunkArticleSink](../../pipelines/ingestion/wechat/storage/local.py) 负责「抓取时
 分批落盘 + 最后合并定稿」,是 A 类里最重的一个,几乎用到接口的全部动作:`write_batch`
-→ `write`;`finalize` 里 `glob` → `list`(仍需按批次号数字排序)、读各批 → `read`、写
-final 与 current → `write`、`rmtree` 临时目录 → `delete_prefix`。构造函数从 3 个 `Path`
-改为 `storage` + 3 个 key。
+→ `write`;`finalize` 里 `glob` → `list`(仍需按批次号数字排序,`list` 只保证字典序)、
+读各批 → `read`、写 final 与 current → `write`、`rmtree` 临时目录 → `delete_prefix`。
+构造函数从 3 个 `Path` 改为 `storage` + `temp_prefix` / `final_key` / `current_key` 三个
+key。
 
-一个设计点:`finalize` 返回的 `ArticleOutput.location`(现为绝对磁盘路径)将改为**逻辑
-key**——与方案②一致、本地云通用(它是信息性字段,只进报告和日志,不参与控制流)。
+`finalize` 返回的 `ArticleOutput.location` 从绝对磁盘路径改为**逻辑 key**——与方案②一致、
+本地云通用(它是信息性字段,只进报告和日志,不参与控制流)。字节与落盘位置不变,直接
+测它的 round-trip 用例同步改用 `LocalStorage` + key。
 
-### Step 5:入口串联 + B 类咽喉点(待做)
+### Step 5:入口串联 + B 类咽喉点(已完成)
 
 > 前置基础:[四、入口串联与逻辑 key 寻址](#四把两者粘起来入口串联与逻辑-key-寻址粘合剂)。
 
-在 `cli.py` / `run_local_*` 创建 storage、按逻辑 key 往下传;**一并迁移 B 类**——
-[json_records](../../pipelines/shared/json_records.py) 与
-[JsonImportCheckpointStore](../../pipelines/shared/import_checkpoint.py);`--input` 等
-参数改为逻辑 key(落实方案②)。B 类必须放在这一步,原因见下节。
+这一步是**收口**:落实组合根 + 方案②,把整条管线改成「认接口不认磁盘」。落地内容:
+
+- **组合根**:[cli.py](../../pipelines/cli.py) 在入口**只建一次** `LocalStorage(DEFAULT_DATA_DIR)`,
+  positional 传给每个 `run_local_*`;各编排函数**不再收 `data_dir`、不再自己建 storage**,
+  改收 `storage` + 逻辑 key。换 S3 从此只改 cli 这一行。
+- **B 类咽喉点迁完**:[json_records](../../pipelines/shared/json_records.py)
+  (`load/write_json_records(storage, key[, records])`)与
+  [JsonImportCheckpointStore](../../pipelines/shared/import_checkpoint.py)
+  (`(storage, key)`,`load` 用 `StorageNotFoundError` 判缺失)。
+- **key 常量化**:[paths.py](../../pipelines/shared/paths.py) 把原来的 `DEFAULT_*_FILE`
+  路径常量换成逻辑 key 常量(`WECHAT_CHECKPOINT_KEY`、`IMPORT_CHECKPOINT_KEY`……)。
+- **方案② 落地**:CLI 的 `--input` / `--checkpoint-file` 从「文件路径」改为「逻辑 key」;
+  pipeline 存进 DB 的 `input_path` / `output_path` / `report_path` 元数据、以及
+  `WechatPipelineRunResult` 的字段(改名 `processed_output_key` / `report_key`)都改为逻辑 key。
+
+**顺带删掉的历史包袱**(方案② 下失去意义,已确认取舍):
+- `import_checkpoint_file_for()`——让 import checkpoint 跟随「任意自定义 input 路径」的推导逻辑,
+  改为固定 key `checkpoints/import_knowledge_base.json`。
+- transform 的 `LEGACY_WECHAT_RAW_INPUT` 回退分支。
+
+B 类为何必须压到这一步(而不能随 A 类提前迁),见下节。
 
 ### Step 6:S3Storage(待做,Phase 3)
 
@@ -338,7 +357,8 @@ key**——与方案②一致、本地云通用(它是信息性字段,只进报�
 
 ## 尚未完成
 
-- **S3Storage 实现**与 AWS 相关配置 —— 留到 future_plan 的 Phase 3。
-- **Step 4/5** —— article sink 迁移、入口串联 + B 类迁移 + `--input` 改逻辑 key。
+- **Step 6:S3Storage 实现**与 AWS 相关配置 —— 全部本地咽喉点(A + B 类)已迁完,入口
+  已收成组合根;只差照同一套 6 个动作写一个走 S3 的后端,入口换一行即可切换。留到
+  future_plan 的 Phase 3。
 - 一个已知的小取舍:失败分支「先写报告 → 再写 DB 记录 → 抛出」,若 DB 写入本身抛错,会
   出现「有报告但无 DB 行」的部分追踪。影响很小,暂不处理。

--- a/docs/design/storage-abstraction.md
+++ b/docs/design/storage-abstraction.md
@@ -1,0 +1,344 @@
+# Pipeline 存储抽象 —— 设计说明
+
+本文记录 pipeline「存储抽象（storage abstraction）」工作的设计细节、背后的取舍,
+以及为看懂这些代码所需的基础知识。整体路线图见
+[future_plan.md](../../future_plan.md) 第 3 项;本文是它的详细展开。
+
+工作按「每步单独实现、单独验证、单独 review」的方式推进(与
+[chat-api-hardening.md](./chat-api-hardening.md) 同一套节奏)。本文兼作**学习参考**,
+面向刚接触数据管线的读者:先给全局大图,再补基础知识,最后才逐步讲实现。凡是用到的
+概念,都在「基础知识」章节从头讲清,正文再引用。
+
+---
+
+## 目录
+
+- [背景](#背景)
+- [先看全局:数据的旅程与「中间人」](#先看全局数据的旅程与中间人)
+- [基础知识](#基础知识)
+  - [一、pipeline 的数据住在哪(data/ 布局)](#一pipeline-的数据住在哪data-布局)
+  - [二、为什么「路径」不够,要「key」](#二为什么路径不够要key)
+  - [三、Storage 接口与后端](#三storage-接口与后端)
+  - [四、把两者粘起来:入口串联与逻辑 key 寻址(粘合剂)](#四把两者粘起来入口串联与逻辑-key-寻址粘合剂)
+- [迁移步骤](#迁移步骤)
+  - [Step 1:接口 + LocalStorage(已完成)](#step-1接口--localstorage已完成)
+  - [Step 2:迁移 reports(已完成)](#step-2迁移-reports已完成)
+  - [Step 3:迁移 wechat harvest checkpoint(已完成)](#step-3迁移-wechat-harvest-checkpoint已完成)
+  - [Step 4:迁移 article sink(待做)](#step-4迁移-article-sink待做)
+  - [Step 5:入口串联 + B 类咽喉点(待做)](#step-5入口串联--b-类咽喉点待做)
+  - [Step 6:S3Storage(待做,Phase 3)](#step-6s3storage待做phase-3)
+- [迁移顺序原则:A 类先、B 类后](#迁移顺序原则a-类先b-类后)
+- [测试策略](#测试策略)
+- [尚未完成](#尚未完成)
+
+---
+
+## 背景
+
+pipeline 目前把每一步的产物写成文件,存在项目的 `data/` 目录里(抓取的原始文章、
+清洗后的记录、断点续跑的存档、运行报告)。这在开发者自己的电脑上没问题。
+
+问题出在部署目标:pipeline 要作为 **Amazon ECS Fargate task** 运行,而 Fargate 的
+本地磁盘是**临时存储**——task 一结束就被清空。用大白话说,那台机器像一间**钟点房**:
+退房时房间里的东西全部清零,下一个 task 是全新的空房间。于是:
+
+- 抓来的文章、清洗结果、报告 —— task 重启后全丢。
+- 「断了能接着跑」的存档(checkpoint)在钟点房模式下形同虚设,每次都得从头来。
+
+所以 pipeline **不能再依赖本地磁盘做长期事实来源**,得改成写到一个**永久的外部仓库**
+——亚马逊的 **Amazon S3**(可理解为「云上的对象存储 / 无限大网盘」)。
+
+如果代码里到处写死「存到本地 `data/` 目录」,那上云时每个 stage 都要改。本工作的目标
+就是**把「存哪、怎么存」抽象成一个可替换的接口**,让:
+
+- 本地开发 → 用「本地文件系统」实现;
+- 上云 → 换成「S3」实现;
+- **上层 pipeline 代码一行都不用动**。
+
+数据库方向已定为 RDS for PostgreSQL,不在本文范围;本文只讲 pipeline **文件产物**的
+存储抽象。
+
+---
+
+## 先看全局:数据的旅程与「中间人」
+
+pipeline 是一条 ETL 流水线:抓 → 洗 → 校 → 灌。**各段之间不是用内存传递数据,而是
+用文件交接**——上一段的输出文件,就是下一段的输入文件:
+
+```text
+微信 API
+   │  ① 抓取(harvest)
+   ▼
+data/raw/          原始快照(不可变)
+   │  ② 清洗(transform)
+   ▼
+data/processed/    加工结果
+   │  (定稿一份)
+   ▼
+data/current/      给下一段用的稳定输入
+   │  ③ 校验 → ④ 向量化 → ⑤ 灌库(import,校验内联其中)
+   ▼
+Postgres knowledge_base 表
+
+旁路:data/checkpoints/(断点续跑存档) · data/reports/(运行报告)
+```
+
+这些 `data/…` 文件就是流水线的**胶水**。存储抽象要做的,就是在「读写这些文件的代码」
+和「文件真正落在哪」之间,插一个**中间人(storage)**:
+
+```text
+          pipeline stage 代码
+                  │  只会喊:存 / 取 / 在不在 / 列出 / 删
+                  ▼
+          ┌───────────────┐
+          │   Storage      │   ← 一份「插头规格」,大家都照这个规格
+          │  (接口/Protocol)│
+          └───────────────┘
+             ╱          ╲
+   LocalStorage          S3Storage(待做)
+   (落到 data/)          (落到 S3 桶)
+```
+
+关键在于:不管背后是本地磁盘还是 S3,中间人对外的**动作名字和用法完全一样**;变的只是
+中间人内部怎么实现。做完全部迁移后,「本地 ↔ S3」只需在**入口**换一个中间人,其余代码
+无感知。
+
+后面的基础知识,分四簇讲清这张图的每一块:数据住在哪(一)、为什么用 key 而不是路径
+(二)、中间人接口长什么样(三)、以及怎么把中间人从入口一路发下去(四,粘合剂)。
+
+---
+
+## 基础知识
+
+### 一、pipeline 的数据住在哪(data/ 布局)
+
+> 这一簇是地基:先知道「有哪些产物、各住哪」,后面「怎么抽象存储」才有对象。
+
+pipeline 的本地产物遵循一套**能干净映射到对象存储**的布局(见
+[pipelines/README.md](../../pipelines/README.md) 与
+[pipelines/shared/paths.py](../../pipelines/shared/paths.py)):
+
+```text
+data/
+  raw/          不可变的源快照
+  processed/    转换后的中间产物
+  current/      给下一段消费的稳定输入
+  checkpoints/  可续跑的本地状态(存档)
+  reports/      运行报告 / 审计摘要
+```
+
+它天然对应未来的云路径:`data/raw/…` → `s3://<bucket>/raw/…`,以此类推。这套「本地目录
+= 未来 S3 前缀」的对应关系,正是存储抽象设计的出发点。
+
+**checkpoint(存档)存什么?** 它不存文章正文,只存「进行到哪 + 少量防错校验」,纯为
+断点续跑。例如 wechat 抓取存档
+([HarvestState](../../pipelines/ingestion/wechat/models.py)):
+
+```json
+{
+  "begin": 120,
+  "total_saved": 120,
+  "valid_count": 98,
+  "seen_links": ["url1", "url2"]
+}
+```
+
+`begin` 让抓取从第 120 篇接着跑,`seen_links` 防重复抓。理解「产物 = 段间胶水、checkpoint
+= 续跑状态」,就能理解为什么这些东西必须落到**永久**存储。
+
+### 二、为什么「路径」不够,要「key」
+
+> 这一簇解释接口最核心的设计选择:用「名字(key)」而不是「文件路径」寻址。
+
+最直觉的做法是让存储接口收一个文件路径(`Path`)。但它对 S3 天生不成立:
+
+- **本地文件系统**按「路径」寻址:有目录、有 `..`、能原子 rename、能 `glob`。
+- **S3 没有「路径 / 目录」这些概念**:它是「一个桶(bucket)+ 桶内的 **key**」。你没法
+  对 S3 说「存到 `/Users/devin/桌面/x.json`」——这句话对云仓库毫无意义。
+
+所以接口改用 **key**——一个 `/` 分隔的**逻辑名字**,而不是文件系统路径:
+
+```text
+key = "reports/pipelines/wechat_pipeline_<run_id>.json"
+       └────────── 逻辑名字,与「本地 or 云」无关 ──────────┘
+```
+
+各后端再把同一个 key 映射到自己的布局:本地拼成 `data/<key>`,S3 拼成
+`s3://<bucket>/<key>`。key 寻址让接口保持中立,是「上 S3 时上层零改动」的前提。
+
+**「找不到」怎么表达?** 接口定义了一个 `StorageNotFoundError`(读一个不存在的 key
+时抛出),让「缺失」有一个与后端无关的统一语义,而不是本地漏 `FileNotFoundError`、S3
+漏另一种异常。
+
+**取舍**:也可以直接用现成库(如 `fsspec` / `smart_open`)一把抹平本地与 S3。这里选择
+**手写一个极小接口**(见下),因为动作只有 6 个、零额外依赖、行为完全可控;代价是 S3
+后端要自己写一小段(Step 6)。对一个仅需「读写整份 JSON + 列目录 + 删」的管线,这个
+取舍偏向简单和可控。
+
+### 三、Storage 接口与后端
+
+> 这一簇是中间人本体:一份接口规格 + 一个本地实现(S3 实现留到 Step 6)。
+
+**接口(规格)** —— [pipelines/shared/storage/base.py](../../pipelines/shared/storage/base.py)
+定义 `Storage` Protocol,动作如下(key 是字符串,内容是字节):
+
+| 动作 | 含义 | 取代了原来的 |
+|---|---|---|
+| `write(key, data)` | 原子写入(实现内部保证) | 临时文件 + `replace` |
+| `read(key)` | 读出字节;缺失抛 `StorageNotFoundError` | `open(...).read` |
+| `exists(key)` | 在不在 | `Path.exists` |
+| `list(prefix)` | 列出某前缀下所有 key(排序) | `glob` |
+| `delete(key)` | 删(缺失不报错) | `unlink` |
+| `delete_prefix(prefix)` | 按前缀整片删 | `rmtree` |
+
+这层里**没有任何「磁盘 / 目录 / S3」字眼**——干净、中立,这正是插头规格该有的样子。
+`Protocol` 意为「规格」:只规定必须会这几个动作,不规定怎么实现。
+
+**本地后端** —— [pipelines/shared/storage/local.py](../../pipelines/shared/storage/local.py)
+的 `LocalStorage(base_dir)`:
+
+- 把 key 映射到 `base_dir/key`。以 `base_dir=data/` 为例,key
+  `reports/pipelines/x.json` 就落在 `data/reports/pipelines/x.json`——**与抽象前的磁盘
+  布局逐字节一致**,现有集成测试察觉不到变化。
+- `write` 内部仍用「临时文件 + 原子 `replace`」,保证崩溃在写一半时不会留下损坏产物;
+  `list` / `delete_prefix` 会忽略 `.tmp` 临时文件。
+- 所有「建目录、临时文件、改名、glob、rmtree」这些脏活,**被收拢进这一个盒子**,咽喉点
+  代码不再重复它们。
+
+**S3 后端(待做)**:同样这 6 个动作,内部改成 S3 的 PUT/GET/list_objects/delete。PUT
+天然原子(不需要临时文件把戏),`delete_prefix` 用「按前缀批量删」。上层零改动即可切换。
+
+### 四、把两者粘起来:入口串联与逻辑 key 寻址(粘合剂)
+
+> 这一簇把前面几簇接上:中间人从哪来、怎么发到各 stage,以及由此定下的寻址规则。
+
+有了接口和本地实现,还差一步:**谁来创建中间人、怎么传给各 stage**。终极形态是——在
+pipeline 的**入口**(`pipelines/cli.py` / `run_local_*`)**只创建一次** `Storage`
+(本地→`LocalStorage`,云→`S3Storage`),连同逻辑 key 一路传给 harvest / transform /
+import 各段;stage 代码不再自己构造 storage、不再处理裸 `Path`。做完这步,本地 ↔ S3
+只需改**入口一行**。
+
+由此定下一个寻址决策(记作**方案②**):
+
+> **artifact 一律用「存储根下的逻辑 key」寻址,不再支持 CLI 传入任意绝对路径。**
+
+- **理由**:S3 没有「绝对路径」概念;「任意本地路径」这个能力本就只对本地成立。
+- **收益**:本地与云写法一致;强制所有数据住在 `data/` 根(或 S3 桶)内,养成好习惯;
+  去掉「任意路径」后门分支,代码更简单。
+- **影响**:`--input` 等参数从「文件路径」改为「根下逻辑 key」(如
+  `current/wechat_articles_processed.json`);需要调试外部文件时,先放进 `data/` 根再
+  引用。
+- **权衡**:牺牲了「随手指一个桌面文件喂给管线」的自由;但这个自由充其量省一次复制,
+  且对 S3 无意义,不值得为它保留一条本地专属分支。
+
+这条粘合剂决定了**哪些咽喉点能先迁、哪些要等入口串联**——见下面的
+[A 类先、B 类后](#迁移顺序原则a-类先b-类后)。
+
+---
+
+## 迁移步骤
+
+咽喉点(现在直接碰文件系统的地方)逐个迁移,**每步单独提交、单独验证**。当前全套件
+共 **178 个单元测试**,每步都要求全绿。
+
+### Step 1:接口 + LocalStorage(已完成)
+
+> 前置基础:[三、Storage 接口与后端](#三storage-接口与后端)。
+
+纯新增,零风险:落地 `Storage` 接口、`StorageNotFoundError`、`LocalStorage`,配 14 个
+单测([tests/unit/test_storage.py](../../tests/unit/test_storage.py))覆盖读写往返、嵌套
+建目录、key→磁盘映射、原子写不留 `.tmp`、`list` 排序与忽略 `.tmp`、`delete` /
+`delete_prefix`。此步不碰任何现有代码。
+
+### Step 2:迁移 reports(已完成)
+
+> 前置基础:[一、data/ 布局](#一pipeline-的数据住在哪data-布局)、
+> [三、Storage 接口](#三storage-接口与后端)。
+
+最小咽喉点试水:[write_json_report](../../pipelines/shared/reports.py) 改为
+`(storage, key, payload)`——只把报告序列化成字节交给中间人,不再自己碰磁盘。唯一调用方
+[wechat_pipeline](../../pipelines/orchestration/wechat_pipeline.py) 用
+`LocalStorage(data_dir)` + `report_file.relative_to(data_dir)` 推出 key,**输出字节与
+落盘位置均不变**。配 [test_reports.py](../../tests/unit/test_reports.py) 3 个测试(含
+「JSON + 末尾换行」的格式锁定)。
+
+> 这是中间人第一次真正接进 pipeline——最小、最独立的一处,证明整条链路可通。
+
+### Step 3:迁移 wechat harvest checkpoint(已完成)
+
+> 前置基础:[一(checkpoint 存什么)](#一pipeline-的数据住在哪data-布局)、
+> [三、Storage 接口](#三storage-接口与后端)。
+
+[JsonFileCheckpointStore](../../pipelines/ingestion/wechat/storage/local.py) 的构造函数从
+收 `state_file: Path` 改为 `(storage, key)`;`load` / `save` / `clear` 改用
+`storage.exists / read / write / delete`。唯一构造点
+[harvest_wechat](../../pipelines/orchestration/harvest_wechat.py) 用
+`LocalStorage(data_dir)` + key `checkpoints/wechat_scraper_state.json`。字节与位置不变;
+同步更新了直接测试它的 round-trip 用例。
+
+### Step 4:迁移 article sink(待做)
+
+> 前置基础:[三、Storage 接口(全部 6 个动作)](#三storage-接口与后端)。
+
+[JsonChunkArticleSink](../../pipelines/ingestion/wechat/storage/local.py) 负责「抓取时
+分批落盘 + 最后合并定稿」,是 A 类里最重的一个,几乎用到接口的全部动作:`write_batch`
+→ `write`;`finalize` 里 `glob` → `list`(仍需按批次号数字排序)、读各批 → `read`、写
+final 与 current → `write`、`rmtree` 临时目录 → `delete_prefix`。构造函数从 3 个 `Path`
+改为 `storage` + 3 个 key。
+
+一个设计点:`finalize` 返回的 `ArticleOutput.location`(现为绝对磁盘路径)将改为**逻辑
+key**——与方案②一致、本地云通用(它是信息性字段,只进报告和日志,不参与控制流)。
+
+### Step 5:入口串联 + B 类咽喉点(待做)
+
+> 前置基础:[四、入口串联与逻辑 key 寻址](#四把两者粘起来入口串联与逻辑-key-寻址粘合剂)。
+
+在 `cli.py` / `run_local_*` 创建 storage、按逻辑 key 往下传;**一并迁移 B 类**——
+[json_records](../../pipelines/shared/json_records.py) 与
+[JsonImportCheckpointStore](../../pipelines/shared/import_checkpoint.py);`--input` 等
+参数改为逻辑 key(落实方案②)。B 类必须放在这一步,原因见下节。
+
+### Step 6:S3Storage(待做,Phase 3)
+
+> 前置基础:[三(S3 后端)](#三storage-接口与后端)。
+
+等真正上 AWS 时,新增 `S3Storage` 类(同一套 6 个动作,内部走 S3),入口把
+`LocalStorage` 换成 `S3Storage` 即可,上层 stage 代码不改。属 future_plan 的 Phase 3。
+
+---
+
+## 迁移顺序原则:A 类先、B 类后
+
+咽喉点按「**存储位置由谁决定**」分两类,这决定了它们的迁移时机:
+
+- **A 类 —— 根来自 `data_dir`(干净,可独立迁移)**:位置纯由 `data_dir` 推出,逻辑 key
+  一目了然。包括 reports、wechat harvest checkpoint、article sink。→ Step 2/3/4。
+- **B 类 —— 根来自「任意 input」(与入口串联绑定)**:位置跟随用户可传任意值的
+  `--input` / `--checkpoint-file`。没有 Step 5 的入口串联,就得不到干净的逻辑 key——
+  硬提前迁只能得到「光秃秃文件名」当 key,对 S3 无意义,且之后还要重做。包括
+  `json_records`、import checkpoint。→ 必须放到 Step 5。
+
+一句话:**能从 `data_dir` 干净推出 key 的先迁;跟随任意路径的,等入口把 storage + key
+串起来再一起迁。**
+
+---
+
+## 测试策略
+
+- **每步跑全套件**:每迁一个咽喉点,`pytest tests/unit -q`(与 CI 同命令)必须全绿,
+  再进下一步。出问题时范围极小,一眼定位是哪一步。
+- **行为字节级不变**:迁移不改变产物内容与落盘位置。序列化保持原样(reports 尾部带
+  `\n`,checkpoint / records / sink 不带),`LocalStorage` 把 key 映射回原物理位置,现有
+  集成测试无感。
+- **接口层独立测试**:`test_storage.py` 用 `tmp_path` 直接测 `LocalStorage` 的每个动作,
+  与业务解耦。
+- **纯标准库**:`LocalStorage` 只用 `pathlib` / `shutil`,可在最小环境下独立验证。
+
+---
+
+## 尚未完成
+
+- **S3Storage 实现**与 AWS 相关配置 —— 留到 future_plan 的 Phase 3。
+- **Step 4/5** —— article sink 迁移、入口串联 + B 类迁移 + `--input` 改逻辑 key。
+- 一个已知的小取舍:失败分支「先写报告 → 再写 DB 记录 → 抛出」,若 DB 写入本身抛错,会
+  出现「有报告但无 DB 行」的部分追踪。影响很小,暂不处理。

--- a/future_plan.md
+++ b/future_plan.md
@@ -266,13 +266,21 @@ data/reports      -> s3://<bucket>/reports
 - `S3Storage`（后续，见 Phase 3）：PUT 天然原子，`list` = list_objects，
   `delete_prefix` = 按前缀删除。上层 stage 代码**零改动**即可切换。
 
-**需要迁移的咽喉点**（现在直接碰文件系统、且都用「临时文件 + 原子 replace」的地方）：
+**需要迁移的咽喉点**（现在直接碰文件系统、且都用「临时文件 + 原子 replace」的地方）。
+按「存储位置由谁决定」分两类，决定它们的迁移时机：
 
-1. `pipelines/shared/reports.py` `write_json_report` —— reports
-2. `pipelines/shared/json_records.py` `load/write_json_records` —— raw / processed
-3. `pipelines/shared/import_checkpoint.py` `JsonImportCheckpointStore` —— import checkpoint
-4. `pipelines/ingestion/wechat/storage/local.py` `JsonFileCheckpointStore` /
-   `JsonChunkArticleSink` —— wechat checkpoint + current
+- **A 类 —— 根来自 `data_dir`（干净，可独立迁移）**：位置纯由 `data_dir` 推出，
+  没有任意 input，逻辑 key 一目了然。
+  1. `pipelines/shared/reports.py` `write_json_report` —— reports
+  2. `pipelines/ingestion/wechat/storage/local.py` `JsonFileCheckpointStore`
+     —— wechat harvest checkpoint（构造点 `harvest_wechat.py`，路径由 `data_dir` 推出）
+  3. `pipelines/ingestion/wechat/storage/local.py` `JsonChunkArticleSink`
+     —— wechat 批次落盘 + current（同上）
+- **B 类 —— 根来自「任意 input」（与入口串联绑定，第 5 步一起做）**：位置跟随用户可
+  传任意值的 `--input` / `--checkpoint-file`，没有第 5 步的入口串联就得不到干净 key。
+  4. `pipelines/shared/json_records.py` `load/write_json_records` —— raw / processed
+  5. `pipelines/shared/import_checkpoint.py` `JsonImportCheckpointStore`
+     —— import checkpoint（路径 = `checkpoint_file or import_checkpoint_file_for(input_file)`）
 
 **入口串联与寻址决策（关键）**：
 
@@ -289,9 +297,9 @@ data/reports      -> s3://<bucket>/reports
   - 影响：`--input` 等参数从「文件路径」改为「根下逻辑 key」（例如
     `current/wechat_articles_processed.json`）；需要调试外部文件时，先放进 `data/`
     根再引用。
-  - `json_records` 的迁移**与本步绑定**：入口把 storage + 逻辑 key 传下来后，
-    `json_records` 一并改为 `(storage, key)` 签名，**不单独提前做**（提前做只能得到
-    光秃秃的文件名 key，对 S3 无意义，且第 5 步还要重做）。
+  - **B 类**（`json_records`、`JsonImportCheckpointStore`）的迁移**与本步绑定**：入口把
+    storage + 逻辑 key 传下来后，它们一并改为 `(storage, key)` 签名，**不单独提前做**
+    （提前做只能得到光秃秃的文件名 key，对 S3 无意义，且第 5 步还要重做）。
 
 #### 分步实施清单（每步单独提交、单独验证）
 
@@ -299,11 +307,14 @@ data/reports      -> s3://<bucket>/reports
 2. ✅ **已完成**：迁移 reports —— `write_json_report(storage, key, payload)`；唯一调用方
    `wechat_pipeline` 用 `LocalStorage(data_dir)` + `report_file.relative_to(data_dir)`，
    输出字节与落盘位置均不变。
-3. 迁移 import checkpoint store（`JsonImportCheckpointStore`）。
-4. 迁移 wechat checkpoint store 与 article sink（`JsonFileCheckpointStore` /
-   `JsonChunkArticleSink`）。
-5. **入口串联**（`cli.py` / `run_local_*`）：创建 storage、按逻辑 key 往下传；
-   顺带迁移 `json_records`；`--input` 等参数改为逻辑 key（落实方案②）。
+3. 迁移 wechat harvest checkpoint（A 类，`JsonFileCheckpointStore`）——构造函数改收
+   `(storage, key)`，唯一构造点 `harvest_wechat.py` 用 `LocalStorage(data_dir)` +
+   key `checkpoints/wechat_scraper_state.json`。
+4. 迁移 wechat article sink（A 类，`JsonChunkArticleSink`）——逻辑更重（写批次 / list /
+   合并 / 拷到 current / 删临时目录），用到 `write`+`list`+`read`+`delete_prefix`，单独一步。
+5. **入口串联**（`cli.py` / `run_local_*`）：创建 storage、按逻辑 key 往下传；一并迁移
+   **B 类**（`json_records` 与 `JsonImportCheckpointStore`）；`--input` 等参数改为逻辑 key
+   （落实方案②）。
 6. `S3Storage` 实现（等真正上 AWS 时做，见 Phase 3），上层不改。
 
 不在本阶段范围：`S3Storage` 实现、AWS 相关配置（留到 Phase 3）。

--- a/future_plan.md
+++ b/future_plan.md
@@ -253,6 +253,61 @@ data/reports      -> s3://<bucket>/reports
 - 失败的 task 可以通过 S3 checkpoint 恢复。
 - API 部署不依赖本地 `data` 目录。
 
+#### 具体设计（storage abstraction）
+
+**统一接口（key 寻址的对象存储，对 S3 友好）** —— 新增 `pipelines/shared/storage/`：
+
+- `base.py`：`Storage` Protocol，动作为 `write(key, data: bytes)` / `read(key) -> bytes`
+  / `exists(key)` / `list(prefix)` / `delete(key)` / `delete_prefix(prefix)`；配套
+  `StorageNotFoundError`。key 是 `/` 分隔的**逻辑名字**（如
+  `reports/pipelines/x.json`），不是文件系统路径，各后端自行把 key 映射到自己的布局。
+- `local.py`：`LocalStorage(base_dir)`，把 key 映射到 `base_dir/key`，内部保留
+  「临时文件 + 原子 `replace`」，**磁盘布局与抽象前完全一致**（现有集成测试无感）。
+- `S3Storage`（后续，见 Phase 3）：PUT 天然原子，`list` = list_objects，
+  `delete_prefix` = 按前缀删除。上层 stage 代码**零改动**即可切换。
+
+**需要迁移的咽喉点**（现在直接碰文件系统、且都用「临时文件 + 原子 replace」的地方）：
+
+1. `pipelines/shared/reports.py` `write_json_report` —— reports
+2. `pipelines/shared/json_records.py` `load/write_json_records` —— raw / processed
+3. `pipelines/shared/import_checkpoint.py` `JsonImportCheckpointStore` —— import checkpoint
+4. `pipelines/ingestion/wechat/storage/local.py` `JsonFileCheckpointStore` /
+   `JsonChunkArticleSink` —— wechat checkpoint + current
+
+**入口串联与寻址决策（关键）**：
+
+- 在 pipeline 入口（`pipelines/cli.py` / `run_local_*`）**只创建一次** `Storage`
+  （本地 → `LocalStorage`，云 → `S3Storage`），连同逻辑 key 一路传给各 stage；
+  stage 代码不再自己构造 storage、不再处理裸 `Path`。做完这步，本地 ↔ S3
+  只需改入口一行。
+- **决策：采用「方案②」—— artifact 一律用「存储根下的逻辑 key」寻址，不再支持
+  CLI 传入任意绝对路径。**
+  - 理由：S3 没有「绝对路径」概念，只有「桶 + key」；「任意本地路径」这个能力
+    本就只对本地成立，对 S3 天生不成立。
+  - 收益：本地与云写法一致；强制所有数据住在 `data/` 根（或 S3 桶）内，养成好习惯；
+    去掉「任意路径」后门分支，代码更简单。
+  - 影响：`--input` 等参数从「文件路径」改为「根下逻辑 key」（例如
+    `current/wechat_articles_processed.json`）；需要调试外部文件时，先放进 `data/`
+    根再引用。
+  - `json_records` 的迁移**与本步绑定**：入口把 storage + 逻辑 key 传下来后，
+    `json_records` 一并改为 `(storage, key)` 签名，**不单独提前做**（提前做只能得到
+    光秃秃的文件名 key，对 S3 无意义，且第 5 步还要重做）。
+
+#### 分步实施清单（每步单独提交、单独验证）
+
+1. ✅ **已完成并提交**：接口 + `LocalStorage` + 单测（纯新增，零风险）。
+2. ✅ **已完成**：迁移 reports —— `write_json_report(storage, key, payload)`；唯一调用方
+   `wechat_pipeline` 用 `LocalStorage(data_dir)` + `report_file.relative_to(data_dir)`，
+   输出字节与落盘位置均不变。
+3. 迁移 import checkpoint store（`JsonImportCheckpointStore`）。
+4. 迁移 wechat checkpoint store 与 article sink（`JsonFileCheckpointStore` /
+   `JsonChunkArticleSink`）。
+5. **入口串联**（`cli.py` / `run_local_*`）：创建 storage、按逻辑 key 往下传；
+   顺带迁移 `json_records`；`--input` 等参数改为逻辑 key（落实方案②）。
+6. `S3Storage` 实现（等真正上 AWS 时做，见 Phase 3），上层不改。
+
+不在本阶段范围：`S3Storage` 实现、AWS 相关配置（留到 Phase 3）。
+
 ## 高优先级容器工作
 
 ### 4. 使用 non-root 用户运行容器
@@ -526,8 +581,10 @@ ECS task count
 
 ### Phase 3：生产 Pipeline
 
-1. 增加 storage abstraction。
-2. 使用 S3 保存 artifact、report 和 checkpoint。
+1. Storage abstraction 已在第 3 项提前落地（接口 + `LocalStorage` + 逐咽喉点迁移
+   + 入口串联，见「### 3」的分步实施清单）；本阶段只需补 `S3Storage` 实现。
+2. 使用 S3 保存 artifact、report 和 checkpoint（入口把 `LocalStorage` 换成
+   `S3Storage`，上层 stage 代码不改）。
 3. 将 pipeline stage 作为一次性或定时 ECS task 运行。
 4. 增加 pipeline alarm 和失败恢复流程。
 

--- a/future_plan.md
+++ b/future_plan.md
@@ -307,14 +307,15 @@ data/reports      -> s3://<bucket>/reports
 2. ✅ **已完成**：迁移 reports —— `write_json_report(storage, key, payload)`；唯一调用方
    `wechat_pipeline` 用 `LocalStorage(data_dir)` + `report_file.relative_to(data_dir)`，
    输出字节与落盘位置均不变。
-3. 迁移 wechat harvest checkpoint（A 类，`JsonFileCheckpointStore`）——构造函数改收
-   `(storage, key)`，唯一构造点 `harvest_wechat.py` 用 `LocalStorage(data_dir)` +
+3. ✅ **已完成**：迁移 wechat harvest checkpoint（A 类，`JsonFileCheckpointStore`）——
+   构造函数改收 `(storage, key)`，唯一构造点 `harvest_wechat.py` 用
    key `checkpoints/wechat_scraper_state.json`。
-4. 迁移 wechat article sink（A 类，`JsonChunkArticleSink`）——逻辑更重（写批次 / list /
-   合并 / 拷到 current / 删临时目录），用到 `write`+`list`+`read`+`delete_prefix`，单独一步。
-5. **入口串联**（`cli.py` / `run_local_*`）：创建 storage、按逻辑 key 往下传；一并迁移
-   **B 类**（`json_records` 与 `JsonImportCheckpointStore`）；`--input` 等参数改为逻辑 key
-   （落实方案②）。
+4. ✅ **已完成**：迁移 wechat article sink（A 类，`JsonChunkArticleSink`）——逻辑更重
+   （写批次 / list / 合并 / 拷到 current / 删临时目录），用到
+   `write`+`list`+`read`+`delete_prefix`；`ArticleOutput.location` 改为逻辑 key。
+5. ✅ **已完成**：**入口串联**（`cli.py` 只建一次 storage、往下传）：一并迁移 **B 类**
+   （`json_records` 与 `JsonImportCheckpointStore`）；`--input` / `--checkpoint-file` 改为
+   逻辑 key（落实方案②）；删掉 `import_checkpoint_file_for` 与 transform legacy 回退。
 6. `S3Storage` 实现（等真正上 AWS 时做，见 Phase 3），上层不改。
 
 不在本阶段范围：`S3Storage` 实现、AWS 相关配置（留到 Phase 3）。

--- a/pipelines/cli.py
+++ b/pipelines/cli.py
@@ -2,14 +2,17 @@ import argparse
 import logging
 import os
 from collections.abc import Sequence
-from pathlib import Path
 from uuid import uuid4
 
 from pipelines.shared.logging import (
     configure_pipeline_logging,
     pipeline_run_context,
 )
-from pipelines.shared.paths import DEFAULT_KNOWLEDGE_BASE_INPUT
+from pipelines.shared.paths import (
+    DEFAULT_DATA_DIR,
+    DEFAULT_KNOWLEDGE_BASE_INPUT_KEY,
+)
+from pipelines.shared.storage import LocalStorage
 
 
 logger = logging.getLogger(__name__)
@@ -36,9 +39,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     import_command.add_argument(
         "--input",
-        type=Path,
-        default=DEFAULT_KNOWLEDGE_BASE_INPUT,
-        help="Processed knowledge-base JSON file.",
+        default=DEFAULT_KNOWLEDGE_BASE_INPUT_KEY,
+        help="Processed knowledge-base record key under the storage root.",
     )
     import_command.add_argument(
         "--database-url",
@@ -59,9 +61,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     import_command.add_argument(
         "--checkpoint-file",
-        type=Path,
         default=None,
-        help="Import checkpoint JSON file.",
+        help=(
+            "Import checkpoint key under the storage root. Defaults to "
+            "checkpoints/import_knowledge_base.json."
+        ),
     )
     import_command.add_argument(
         "--reset-checkpoint",
@@ -132,7 +136,7 @@ def _run_command(
             run_local_harvest,
         )
 
-        result = run_local_harvest()
+        result = run_local_harvest(LocalStorage(DEFAULT_DATA_DIR))
         logger.info(
             "WeChat harvest completed",
             extra={
@@ -146,7 +150,7 @@ def _run_command(
             run_local_transform,
         )
 
-        result = run_local_transform()
+        result = run_local_transform(LocalStorage(DEFAULT_DATA_DIR))
         logger.info(
             "WeChat transformation completed",
             extra={
@@ -166,11 +170,12 @@ def _run_command(
             )
 
         result = run_local_import(
+            LocalStorage(DEFAULT_DATA_DIR),
             database_url=args.database_url,
-            input_file=args.input,
+            input_key=args.input,
             limit=args.limit,
             batch_size=args.batch_size,
-            checkpoint_file=args.checkpoint_file,
+            checkpoint_key=args.checkpoint_file,
             reset_checkpoint=args.reset_checkpoint,
         )
         logger.info(
@@ -196,6 +201,7 @@ def _run_command(
             )
 
         result = run_local_wechat_pipeline(
+            LocalStorage(DEFAULT_DATA_DIR),
             database_url=args.database_url,
             batch_size=args.batch_size,
             reset_import_checkpoint=args.reset_import_checkpoint,

--- a/pipelines/ingestion/wechat/storage/local.py
+++ b/pipelines/ingestion/wechat/storage/local.py
@@ -1,6 +1,4 @@
 import json
-import shutil
-from pathlib import Path
 from typing import Any
 
 from pipelines.ingestion.wechat.models import ArticleOutput, HarvestState
@@ -42,64 +40,48 @@ class JsonFileCheckpointStore:
 class JsonChunkArticleSink:
     def __init__(
         self,
-        temp_dir: Path,
-        final_file: Path,
-        current_file: Path | None = None,
+        storage: Storage,
+        temp_prefix: str,
+        final_key: str,
+        current_key: str | None = None,
     ):
-        self.temp_dir = temp_dir
-        self.final_file = final_file
-        self.current_file = current_file
+        self.storage = storage
+        self.temp_prefix = temp_prefix
+        self.final_key = final_key
+        self.current_key = current_key
 
     def write_batch(
         self,
         batch_id: int,
         articles: list[dict[str, Any]],
     ) -> None:
-        self.temp_dir.mkdir(parents=True, exist_ok=True)
-        batch_file = self.temp_dir / f"batch_{batch_id}.json"
-        temporary_file = batch_file.with_suffix(".json.tmp")
-
-        with temporary_file.open("w", encoding="utf-8") as file:
-            json.dump(articles, file, ensure_ascii=False, indent=2)
-
-        temporary_file.replace(batch_file)
+        document = json.dumps(articles, ensure_ascii=False, indent=2)
+        self.storage.write(
+            f"{self.temp_prefix}/batch_{batch_id}.json",
+            document.encode("utf-8"),
+        )
 
     def finalize(self) -> ArticleOutput:
         articles: list[dict[str, Any]] = []
-        batch_files = (
-            list(self.temp_dir.glob("batch_*.json"))
-            if self.temp_dir.exists()
-            else []
-        )
+        for key in sorted(self.storage.list(self.temp_prefix), key=_batch_offset):
+            articles.extend(json.loads(self.storage.read(key)))
 
-        for batch_file in sorted(batch_files, key=_batch_offset):
-            with batch_file.open("r", encoding="utf-8") as file:
-                articles.extend(json.load(file))
+        document = json.dumps(
+            articles, ensure_ascii=False, indent=2
+        ).encode("utf-8")
+        self.storage.write(self.final_key, document)
 
-        self.final_file.parent.mkdir(parents=True, exist_ok=True)
-        temporary_file = self.final_file.with_suffix(
-            f"{self.final_file.suffix}.tmp"
-        )
-        with temporary_file.open("w", encoding="utf-8") as file:
-            json.dump(articles, file, ensure_ascii=False, indent=2)
-        temporary_file.replace(self.final_file)
+        if self.current_key is not None:
+            self.storage.write(self.current_key, document)
 
-        if self.current_file is not None:
-            self.current_file.parent.mkdir(parents=True, exist_ok=True)
-            temporary_current_file = self.current_file.with_suffix(
-                f"{self.current_file.suffix}.tmp"
-            )
-            shutil.copyfile(self.final_file, temporary_current_file)
-            temporary_current_file.replace(self.current_file)
-
-        if self.temp_dir.exists():
-            shutil.rmtree(self.temp_dir)
+        self.storage.delete_prefix(self.temp_prefix)
 
         return ArticleOutput(
-            location=str(self.final_file.resolve()),
+            location=self.final_key,
             article_count=len(articles),
         )
 
 
-def _batch_offset(batch_file: Path) -> int:
-    return int(batch_file.stem.removeprefix("batch_"))
+def _batch_offset(key: str) -> int:
+    stem = key.rsplit("/", 1)[-1].removesuffix(".json")
+    return int(stem.removeprefix("batch_"))

--- a/pipelines/ingestion/wechat/storage/local.py
+++ b/pipelines/ingestion/wechat/storage/local.py
@@ -4,18 +4,19 @@ from pathlib import Path
 from typing import Any
 
 from pipelines.ingestion.wechat.models import ArticleOutput, HarvestState
+from pipelines.shared.storage import Storage
 
 
 class JsonFileCheckpointStore:
-    def __init__(self, state_file: Path):
-        self.state_file = state_file
+    def __init__(self, storage: Storage, key: str):
+        self.storage = storage
+        self.key = key
 
     def load(self) -> HarvestState:
-        if not self.state_file.exists():
+        if not self.storage.exists(self.key):
             return HarvestState()
 
-        with self.state_file.open("r", encoding="utf-8") as file:
-            payload = json.load(file)
+        payload = json.loads(self.storage.read(self.key))
 
         return HarvestState(
             begin=payload.get("begin", 0),
@@ -25,25 +26,17 @@ class JsonFileCheckpointStore:
         )
 
     def save(self, state: HarvestState) -> None:
-        self.state_file.parent.mkdir(parents=True, exist_ok=True)
-        temporary_file = self.state_file.with_suffix(
-            f"{self.state_file.suffix}.tmp"
-        )
         payload = {
             "begin": state.begin,
             "total_saved": state.total_saved,
             "valid_count": state.valid_count,
             "seen_links": sorted(state.seen_links),
         }
-
-        with temporary_file.open("w", encoding="utf-8") as file:
-            json.dump(payload, file, ensure_ascii=False, indent=2)
-
-        temporary_file.replace(self.state_file)
+        document = json.dumps(payload, ensure_ascii=False, indent=2)
+        self.storage.write(self.key, document.encode("utf-8"))
 
     def clear(self) -> None:
-        if self.state_file.exists():
-            self.state_file.unlink()
+        self.storage.delete(self.key)
 
 
 class JsonChunkArticleSink:

--- a/pipelines/orchestration/harvest_wechat.py
+++ b/pipelines/orchestration/harvest_wechat.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from pathlib import Path
 
 from pipelines.ingestion.wechat import (
     HarvestResult,
@@ -12,66 +11,39 @@ from pipelines.ingestion.wechat.storage import (
     JsonFileCheckpointStore,
 )
 from pipelines.shared.paths import (
-    DEFAULT_CURRENT_DATA_DIR,
-    DEFAULT_DATA_DIR,
-    DEFAULT_WECHAT_CHECKPOINT_FILE,
-    DEFAULT_WECHAT_RAW_DIR,
-    DEFAULT_WECHAT_TEMP_CHUNKS_DIR,
+    WECHAT_CHECKPOINT_KEY,
+    WECHAT_RAW_CURRENT_KEY,
+    WECHAT_RAW_DIR_KEY,
+    WECHAT_TEMP_CHUNKS_PREFIX,
 )
-from pipelines.shared.storage import LocalStorage
+from pipelines.shared.storage import Storage
 
 
-def build_wechat_raw_snapshot_file(
+def build_wechat_raw_snapshot_key(
     *,
-    data_dir: Path = DEFAULT_DATA_DIR,
     run_started_at: datetime | None = None,
-) -> Path:
+) -> str:
     run_started_at = run_started_at or datetime.now(timezone.utc)
     timestamp = (
         run_started_at.astimezone(timezone.utc)
         .strftime("%Y%m%dT%H%M%SZ")
     )
-    if data_dir == DEFAULT_DATA_DIR:
-        return DEFAULT_WECHAT_RAW_DIR / f"wechat_articles_{timestamp}.json"
-    return data_dir / "raw" / "wechat" / f"wechat_articles_{timestamp}.json"
+    return f"{WECHAT_RAW_DIR_KEY}/wechat_articles_{timestamp}.json"
 
 
 def run_local_harvest(
+    storage: Storage,
     *,
     config: WechatHarvesterConfig | None = None,
-    data_dir: Path = DEFAULT_DATA_DIR,
     run_started_at: datetime | None = None,
 ) -> HarvestResult:
     config = config or WechatHarvesterConfig.from_environment()
-    current_file = (
-        DEFAULT_CURRENT_DATA_DIR / "wechat_articles_all.json"
-        if data_dir == DEFAULT_DATA_DIR
-        else data_dir / "current" / "wechat_articles_all.json"
-    )
-    checkpoint_file = (
-        DEFAULT_WECHAT_CHECKPOINT_FILE
-        if data_dir == DEFAULT_DATA_DIR
-        else data_dir / "checkpoints" / "wechat_scraper_state.json"
-    )
-    temp_chunks_dir = (
-        DEFAULT_WECHAT_TEMP_CHUNKS_DIR
-        if data_dir == DEFAULT_DATA_DIR
-        else data_dir / "checkpoints" / "wechat_temp_chunks"
-    )
-    storage = LocalStorage(data_dir)
-    checkpoint_store = JsonFileCheckpointStore(
-        storage,
-        checkpoint_file.relative_to(data_dir).as_posix(),
-    )
-    raw_snapshot_file = build_wechat_raw_snapshot_file(
-        data_dir=data_dir,
-        run_started_at=run_started_at,
-    )
+    checkpoint_store = JsonFileCheckpointStore(storage, WECHAT_CHECKPOINT_KEY)
     article_sink = JsonChunkArticleSink(
         storage,
-        temp_chunks_dir.relative_to(data_dir).as_posix(),
-        raw_snapshot_file.relative_to(data_dir).as_posix(),
-        current_file.relative_to(data_dir).as_posix(),
+        WECHAT_TEMP_CHUNKS_PREFIX,
+        build_wechat_raw_snapshot_key(run_started_at=run_started_at),
+        WECHAT_RAW_CURRENT_KEY,
     )
 
     return harvest_wechat(

--- a/pipelines/orchestration/harvest_wechat.py
+++ b/pipelines/orchestration/harvest_wechat.py
@@ -68,9 +68,10 @@ def run_local_harvest(
         run_started_at=run_started_at,
     )
     article_sink = JsonChunkArticleSink(
-        temp_dir=temp_chunks_dir,
-        final_file=raw_snapshot_file,
-        current_file=current_file,
+        storage,
+        temp_chunks_dir.relative_to(data_dir).as_posix(),
+        raw_snapshot_file.relative_to(data_dir).as_posix(),
+        current_file.relative_to(data_dir).as_posix(),
     )
 
     return harvest_wechat(

--- a/pipelines/orchestration/harvest_wechat.py
+++ b/pipelines/orchestration/harvest_wechat.py
@@ -18,6 +18,7 @@ from pipelines.shared.paths import (
     DEFAULT_WECHAT_RAW_DIR,
     DEFAULT_WECHAT_TEMP_CHUNKS_DIR,
 )
+from pipelines.shared.storage import LocalStorage
 
 
 def build_wechat_raw_snapshot_file(
@@ -57,8 +58,10 @@ def run_local_harvest(
         if data_dir == DEFAULT_DATA_DIR
         else data_dir / "checkpoints" / "wechat_temp_chunks"
     )
+    storage = LocalStorage(data_dir)
     checkpoint_store = JsonFileCheckpointStore(
-        checkpoint_file
+        storage,
+        checkpoint_file.relative_to(data_dir).as_posix(),
     )
     raw_snapshot_file = build_wechat_raw_snapshot_file(
         data_dir=data_dir,

--- a/pipelines/orchestration/import_knowledge_base.py
+++ b/pipelines/orchestration/import_knowledge_base.py
@@ -2,7 +2,6 @@ import logging
 import math
 import time
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
@@ -23,9 +22,10 @@ from pipelines.shared.import_checkpoint import (
 )
 from pipelines.shared.json_records import load_json_records
 from pipelines.shared.paths import (
-    DEFAULT_KNOWLEDGE_BASE_INPUT,
-    import_checkpoint_file_for,
+    DEFAULT_KNOWLEDGE_BASE_INPUT_KEY,
+    IMPORT_CHECKPOINT_KEY,
 )
+from pipelines.shared.storage import Storage
 from pipelines.validation.knowledge_base_records import validate_records
 
 
@@ -235,15 +235,16 @@ def _import_validated_records(
 
 
 def run_local_import(
+    storage: Storage,
     database_url: str,
     *,
-    input_file: Path = DEFAULT_KNOWLEDGE_BASE_INPUT,
+    input_key: str = DEFAULT_KNOWLEDGE_BASE_INPUT_KEY,
     model_name: str | None = None,
     model_revision: str | None = None,
     table_name: str | None = None,
     limit: int | None = None,
     batch_size: int = 100,
-    checkpoint_file: Path | None = None,
+    checkpoint_key: str | None = None,
     reset_checkpoint: bool = False,
 ) -> ImportResult:
     if limit is not None and limit < 0:
@@ -251,7 +252,7 @@ def run_local_import(
     if batch_size <= 0:
         raise ValueError("batch_size must be greater than zero")
 
-    records = load_json_records(input_file)
+    records = load_json_records(storage, input_key)
     if limit is not None:
         records = records[:limit]
 
@@ -267,7 +268,8 @@ def run_local_import(
         )
     table_name = table_name or rag_config["pgvector"]["table_name"]
     checkpoint_store = JsonImportCheckpointStore(
-        checkpoint_file or import_checkpoint_file_for(input_file)
+        storage,
+        checkpoint_key or IMPORT_CHECKPOINT_KEY,
     )
     if reset_checkpoint:
         checkpoint_store.clear()

--- a/pipelines/orchestration/transform_wechat.py
+++ b/pipelines/orchestration/transform_wechat.py
@@ -1,71 +1,53 @@
 from datetime import date, datetime, timezone
-from pathlib import Path
 
 from pipelines.shared.json_records import (
     load_json_records,
     write_json_records,
 )
 from pipelines.shared.paths import (
-    DEFAULT_DATA_DIR,
-    DEFAULT_KNOWLEDGE_BASE_PROCESSED_DIR,
-    DEFAULT_KNOWLEDGE_BASE_INPUT,
-    DEFAULT_WECHAT_RAW_INPUT,
-    LEGACY_WECHAT_RAW_INPUT,
+    DEFAULT_KNOWLEDGE_BASE_INPUT_KEY,
+    DEFAULT_WECHAT_RAW_INPUT_KEY,
+    KNOWLEDGE_BASE_PROCESSED_DIR_KEY,
 )
+from pipelines.shared.storage import Storage
 from pipelines.transform.wechat_articles import (
     WechatTransformResult,
     transform_articles,
 )
 
 
-def build_knowledge_base_snapshot_file(
+def build_knowledge_base_snapshot_key(
     *,
-    data_dir: Path = DEFAULT_DATA_DIR,
     run_started_at: datetime | None = None,
-) -> Path:
+) -> str:
     run_started_at = run_started_at or datetime.now(timezone.utc)
     timestamp = (
         run_started_at.astimezone(timezone.utc)
         .strftime("%Y%m%dT%H%M%SZ")
     )
-    if data_dir == DEFAULT_DATA_DIR:
-        return (
-            DEFAULT_KNOWLEDGE_BASE_PROCESSED_DIR
-            / f"wechat_articles_processed_{timestamp}.json"
-        )
     return (
-        data_dir
-        / "processed"
-        / "knowledge_base"
-        / f"wechat_articles_processed_{timestamp}.json"
+        f"{KNOWLEDGE_BASE_PROCESSED_DIR_KEY}"
+        f"/wechat_articles_processed_{timestamp}.json"
     )
 
 
 def run_local_transform(
+    storage: Storage,
     *,
-    input_file: Path = DEFAULT_WECHAT_RAW_INPUT,
-    output_file: Path = DEFAULT_KNOWLEDGE_BASE_INPUT,
-    snapshot_file: Path | None = None,
-    data_dir: Path = DEFAULT_DATA_DIR,
+    input_key: str = DEFAULT_WECHAT_RAW_INPUT_KEY,
+    output_key: str = DEFAULT_KNOWLEDGE_BASE_INPUT_KEY,
+    snapshot_key: str | None = None,
     created_at: date | None = None,
     run_started_at: datetime | None = None,
 ) -> WechatTransformResult:
-    if (
-        input_file == DEFAULT_WECHAT_RAW_INPUT
-        and not input_file.exists()
-        and LEGACY_WECHAT_RAW_INPUT.exists()
-    ):
-        input_file = LEGACY_WECHAT_RAW_INPUT
-
-    raw_articles = load_json_records(input_file)
+    raw_articles = load_json_records(storage, input_key)
     result = transform_articles(
         raw_articles,
         created_at=created_at or date.today(),
     )
-    snapshot_file = snapshot_file or build_knowledge_base_snapshot_file(
-        data_dir=data_dir,
+    snapshot_key = snapshot_key or build_knowledge_base_snapshot_key(
         run_started_at=run_started_at,
     )
-    write_json_records(snapshot_file, result.records)
-    write_json_records(output_file, result.records)
+    write_json_records(storage, snapshot_key, result.records)
+    write_json_records(storage, output_key, result.records)
     return result

--- a/pipelines/orchestration/validate_knowledge_base.py
+++ b/pipelines/orchestration/validate_knowledge_base.py
@@ -1,16 +1,19 @@
 import argparse
-from pathlib import Path
 
 from pipelines.shared.json_records import load_json_records
-from pipelines.shared.paths import DEFAULT_KNOWLEDGE_BASE_INPUT
+from pipelines.shared.paths import (
+    DEFAULT_DATA_DIR,
+    DEFAULT_KNOWLEDGE_BASE_INPUT_KEY,
+)
+from pipelines.shared.storage import LocalStorage, Storage
 from pipelines.validation.knowledge_base_records import validate_records
 
 
-def dry_run(input_file: Path) -> int:
-    records = load_json_records(input_file)
+def dry_run(storage: Storage, key: str) -> int:
+    records = load_json_records(storage, key)
     errors = validate_records(records)
 
-    print(f"Input file: {input_file}")
+    print(f"Input key: {key}")
     print(f"Rows found: {len(records)}")
 
     if errors:
@@ -32,13 +35,12 @@ def main() -> int:
     )
     parser.add_argument(
         "--input",
-        type=Path,
-        default=DEFAULT_KNOWLEDGE_BASE_INPUT,
-        help="Processed JSON file to validate.",
+        default=DEFAULT_KNOWLEDGE_BASE_INPUT_KEY,
+        help="Processed record key under the storage root.",
     )
     args = parser.parse_args()
 
-    return dry_run(args.input)
+    return dry_run(LocalStorage(DEFAULT_DATA_DIR), args.input)
 
 
 if __name__ == "__main__":

--- a/pipelines/orchestration/wechat_pipeline.py
+++ b/pipelines/orchestration/wechat_pipeline.py
@@ -19,6 +19,7 @@ from pipelines.shared.paths import (
     DEFAULT_PIPELINE_REPORTS_DIR,
 )
 from pipelines.shared.reports import write_json_report
+from pipelines.shared.storage import LocalStorage
 
 
 logger = logging.getLogger(__name__)
@@ -273,7 +274,13 @@ def _write_wechat_pipeline_report(
             }
         )
 
-    return write_json_report(report_file, payload)
+    storage = LocalStorage(data_dir)
+    write_json_report(
+        storage,
+        report_file.relative_to(data_dir).as_posix(),
+        payload,
+    )
+    return report_file
 
 
 def _run_stage(

--- a/pipelines/orchestration/wechat_pipeline.py
+++ b/pipelines/orchestration/wechat_pipeline.py
@@ -3,7 +3,6 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import date, datetime, timezone
-from pathlib import Path
 from typing import Any, Protocol
 from uuid import uuid4
 
@@ -14,12 +13,12 @@ from pipelines.orchestration.import_knowledge_base import run_local_import
 from pipelines.orchestration.transform_wechat import run_local_transform
 from pipelines.shared.logging import pipeline_run_context
 from pipelines.shared.paths import (
-    DEFAULT_CURRENT_DATA_DIR,
-    DEFAULT_DATA_DIR,
-    DEFAULT_PIPELINE_REPORTS_DIR,
+    KNOWLEDGE_BASE_CURRENT_KEY,
+    PIPELINE_REPORTS_PREFIX,
+    WECHAT_RAW_CURRENT_KEY,
 )
 from pipelines.shared.reports import write_json_report
-from pipelines.shared.storage import LocalStorage
+from pipelines.shared.storage import Storage
 
 
 logger = logging.getLogger(__name__)
@@ -39,8 +38,8 @@ class WechatPipelineRunResult:
     attempted_import_count: int
     affected_count: int
     raw_output_location: str
-    processed_output_file: Path
-    report_file: Path | None = None
+    processed_output_key: str
+    report_key: str | None = None
 
     @property
     def rejected_count(self) -> int:
@@ -48,37 +47,24 @@ class WechatPipelineRunResult:
 
 
 def run_local_wechat_pipeline(
+    storage: Storage,
     database_url: str,
     *,
     harvester_config: WechatHarvesterConfig | None = None,
-    data_dir: Path = DEFAULT_DATA_DIR,
     created_at: date | None = None,
     model_name: str | None = None,
     model_revision: str | None = None,
     table_name: str | None = None,
     batch_size: int = 100,
-    import_checkpoint_file: Path | None = None,
+    import_checkpoint_key: str | None = None,
     reset_import_checkpoint: bool = False,
     pipeline_run_loader: PipelineRunMetadataLoader | None = None,
     run_id: str | None = None,
 ) -> WechatPipelineRunResult:
     run_id = run_id or str(uuid4())
     run_started_at = datetime.now(timezone.utc)
-    raw_output_file = data_dir / "wechat_articles_all.json"
-    processed_output_file = data_dir / "wechat_articles_processed.json"
-    if data_dir == DEFAULT_DATA_DIR:
-        raw_output_file = (
-            DEFAULT_CURRENT_DATA_DIR / "wechat_articles_all.json"
-        )
-        processed_output_file = (
-            DEFAULT_CURRENT_DATA_DIR
-            / "wechat_articles_processed.json"
-        )
-    else:
-        raw_output_file = data_dir / "current" / "wechat_articles_all.json"
-        processed_output_file = (
-            data_dir / "current" / "wechat_articles_processed.json"
-        )
+    raw_output_key = WECHAT_RAW_CURRENT_KEY
+    processed_output_key = KNOWLEDGE_BASE_CURRENT_KEY
     run_started = time.perf_counter()
     with pipeline_run_context(run_id):
         logger.info(
@@ -92,7 +78,7 @@ def run_local_wechat_pipeline(
                 pipeline_name="wechat",
                 status="started",
                 started_at=run_started_at,
-                input_path=str(raw_output_file),
+                input_path=raw_output_key,
             ),
         )
 
@@ -100,8 +86,8 @@ def run_local_wechat_pipeline(
             harvest_result = _run_stage(
                 "harvest",
                 lambda: run_local_harvest(
+                    storage,
                     config=harvester_config,
-                    data_dir=data_dir,
                     run_started_at=run_started_at,
                 ),
                 lambda result: {
@@ -111,9 +97,9 @@ def run_local_wechat_pipeline(
             transform_result = _run_stage(
                 "transform",
                 lambda: run_local_transform(
-                    input_file=raw_output_file,
-                    output_file=processed_output_file,
-                    data_dir=data_dir,
+                    storage,
+                    input_key=raw_output_key,
+                    output_key=processed_output_key,
                     created_at=created_at,
                     run_started_at=run_started_at,
                 ),
@@ -124,13 +110,14 @@ def run_local_wechat_pipeline(
             import_result = _run_stage(
                 "import",
                 lambda: run_local_import(
-                    database_url=database_url,
-                    input_file=processed_output_file,
+                    storage,
+                    database_url,
+                    input_key=processed_output_key,
                     model_name=model_name,
                     model_revision=model_revision,
                     table_name=table_name,
                     batch_size=batch_size,
-                    checkpoint_file=import_checkpoint_file,
+                    checkpoint_key=import_checkpoint_key,
                     reset_checkpoint=reset_import_checkpoint,
                 ),
                 lambda result: {
@@ -140,8 +127,8 @@ def run_local_wechat_pipeline(
             )
         except Exception as error:
             finished_at = datetime.now(timezone.utc)
-            report_file = _write_wechat_pipeline_report(
-                data_dir=data_dir,
+            report_key = _write_wechat_pipeline_report(
+                storage=storage,
                 run_id=run_id,
                 status="failed",
                 started_at=run_started_at,
@@ -156,9 +143,9 @@ def run_local_wechat_pipeline(
                     status="failed",
                     started_at=run_started_at,
                     finished_at=finished_at,
-                    input_path=str(raw_output_file),
-                    output_path=str(processed_output_file),
-                    report_path=str(report_file),
+                    input_path=raw_output_key,
+                    output_path=processed_output_key,
+                    report_path=report_key,
                     error_type=type(error).__name__,
                     error_message=str(error),
                 ),
@@ -174,18 +161,18 @@ def run_local_wechat_pipeline(
             attempted_import_count=import_result.attempted_count,
             affected_count=import_result.affected_count,
             raw_output_location=harvest_result.output_location,
-            processed_output_file=processed_output_file,
+            processed_output_key=processed_output_key,
         )
         finished_at = datetime.now(timezone.utc)
-        report_file = _write_wechat_pipeline_report(
-            data_dir=data_dir,
+        report_key = _write_wechat_pipeline_report(
+            storage=storage,
             run_id=run_id,
             status="completed",
             started_at=run_started_at,
             finished_at=finished_at,
             result=result,
         )
-        result = replace(result, report_file=report_file)
+        result = replace(result, report_key=report_key)
         _upsert_pipeline_run_metadata(
             pipeline_run_loader,
             PipelineRunRecord(
@@ -194,9 +181,9 @@ def run_local_wechat_pipeline(
                 status="completed",
                 started_at=run_started_at,
                 finished_at=finished_at,
-                input_path=str(raw_output_file),
-                output_path=str(processed_output_file),
-                report_path=str(report_file),
+                input_path=raw_output_key,
+                output_path=processed_output_key,
+                report_path=report_key,
                 record_count=result.transformed_count,
                 affected_count=result.affected_count,
             ),
@@ -225,26 +212,17 @@ def _upsert_pipeline_run_metadata(
     loader.upsert_run(record)
 
 
-def _pipeline_reports_dir(data_dir: Path) -> Path:
-    if data_dir == DEFAULT_DATA_DIR:
-        return DEFAULT_PIPELINE_REPORTS_DIR
-    return data_dir / "reports" / "pipelines"
-
-
 def _write_wechat_pipeline_report(
     *,
-    data_dir: Path,
+    storage: Storage,
     run_id: str,
     status: str,
     started_at: datetime,
     finished_at: datetime,
     result: WechatPipelineRunResult | None = None,
     error: Exception | None = None,
-) -> Path:
-    report_file = (
-        _pipeline_reports_dir(data_dir)
-        / f"wechat_pipeline_{run_id}.json"
-    )
+) -> str:
+    report_key = f"{PIPELINE_REPORTS_PREFIX}/wechat_pipeline_{run_id}.json"
     payload: dict[str, Any] = {
         "run_id": run_id,
         "pipeline": "wechat",
@@ -256,7 +234,7 @@ def _write_wechat_pipeline_report(
         payload.update(
             {
                 "raw_output_location": result.raw_output_location,
-                "processed_output_file": str(result.processed_output_file),
+                "processed_output_key": result.processed_output_key,
                 "harvested_count": result.harvested_count,
                 "transformed_count": result.transformed_count,
                 "skipped_count": result.skipped_count,
@@ -274,13 +252,8 @@ def _write_wechat_pipeline_report(
             }
         )
 
-    storage = LocalStorage(data_dir)
-    write_json_report(
-        storage,
-        report_file.relative_to(data_dir).as_posix(),
-        payload,
-    )
-    return report_file
+    write_json_report(storage, report_key, payload)
+    return report_key
 
 
 def _run_stage(

--- a/pipelines/shared/import_checkpoint.py
+++ b/pipelines/shared/import_checkpoint.py
@@ -3,8 +3,9 @@ import json
 import logging
 from copy import deepcopy
 from dataclasses import asdict, dataclass, replace
-from pathlib import Path
 from typing import Any, Protocol
+
+from pipelines.shared.storage import Storage, StorageNotFoundError
 
 
 logger = logging.getLogger(__name__)
@@ -39,15 +40,15 @@ class ImportCheckpointStore(Protocol):
 
 
 class JsonImportCheckpointStore:
-    def __init__(self, checkpoint_file: Path):
-        self.checkpoint_file = checkpoint_file
+    def __init__(self, storage: Storage, key: str):
+        self.storage = storage
+        self.key = key
 
     def load(self) -> ImportCheckpoint | None:
-        if not self.checkpoint_file.exists():
+        try:
+            payload = json.loads(self.storage.read(self.key))
+        except StorageNotFoundError:
             return None
-
-        with self.checkpoint_file.open("r", encoding="utf-8") as file:
-            payload = json.load(file)
 
         return ImportCheckpoint(
             identity=ImportCheckpointIdentity(**payload["identity"]),
@@ -61,24 +62,15 @@ class JsonImportCheckpointStore:
         )
 
     def save(self, checkpoint: ImportCheckpoint) -> None:
-        self.checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
-        temporary_file = self.checkpoint_file.with_suffix(
-            f"{self.checkpoint_file.suffix}.tmp"
+        document = json.dumps(
+            asdict(checkpoint),
+            ensure_ascii=False,
+            indent=2,
         )
-
-        with temporary_file.open("w", encoding="utf-8") as file:
-            json.dump(
-                asdict(checkpoint),
-                file,
-                ensure_ascii=False,
-                indent=2,
-            )
-
-        temporary_file.replace(self.checkpoint_file)
+        self.storage.write(self.key, document.encode("utf-8"))
 
     def clear(self) -> None:
-        if self.checkpoint_file.exists():
-            self.checkpoint_file.unlink()
+        self.storage.delete(self.key)
 
 
 class MemoryImportCheckpointStore:

--- a/pipelines/shared/json_records.py
+++ b/pipelines/shared/json_records.py
@@ -1,26 +1,22 @@
 import json
-from pathlib import Path
 from typing import Any
 
+from pipelines.shared.storage import Storage
 
-def load_json_records(input_file: Path) -> list[dict[str, Any]]:
-    with input_file.open("r", encoding="utf-8") as file:
-        records = json.load(file)
+
+def load_json_records(storage: Storage, key: str) -> list[dict[str, Any]]:
+    records = json.loads(storage.read(key))
 
     if not isinstance(records, list):
-        raise ValueError(f"Expected a JSON list in {input_file}")
+        raise ValueError(f"Expected a JSON list in {key}")
 
     return records
 
 
 def write_json_records(
-    output_file: Path,
+    storage: Storage,
+    key: str,
     records: list[dict[str, Any]],
 ) -> None:
-    output_file.parent.mkdir(parents=True, exist_ok=True)
-    temporary_file = output_file.with_suffix(f"{output_file.suffix}.tmp")
-
-    with temporary_file.open("w", encoding="utf-8") as file:
-        json.dump(records, file, ensure_ascii=False, indent=2)
-
-    temporary_file.replace(output_file)
+    document = json.dumps(records, ensure_ascii=False, indent=2)
+    storage.write(key, document.encode("utf-8"))

--- a/pipelines/shared/paths.py
+++ b/pipelines/shared/paths.py
@@ -2,49 +2,23 @@ from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# Local storage root. Logical keys below are resolved relative to this
+# directory by ``LocalStorage``; in the cloud the same keys live under an S3
+# bucket. Artifacts are always addressed by logical key, never by filesystem
+# path (see docs/design/storage-abstraction.md).
 DEFAULT_DATA_DIR = PROJECT_ROOT / "data"
-DEFAULT_RAW_DATA_DIR = DEFAULT_DATA_DIR / "raw"
-DEFAULT_PROCESSED_DATA_DIR = DEFAULT_DATA_DIR / "processed"
-DEFAULT_CURRENT_DATA_DIR = DEFAULT_DATA_DIR / "current"
-DEFAULT_CHECKPOINT_DATA_DIR = DEFAULT_DATA_DIR / "checkpoints"
-DEFAULT_REPORTS_DATA_DIR = DEFAULT_DATA_DIR / "reports"
-DEFAULT_WECHAT_RAW_DIR = DEFAULT_RAW_DATA_DIR / "wechat"
-DEFAULT_KNOWLEDGE_BASE_PROCESSED_DIR = (
-    DEFAULT_PROCESSED_DATA_DIR / "knowledge_base"
-)
-DEFAULT_WECHAT_CHECKPOINT_FILE = (
-    DEFAULT_CHECKPOINT_DATA_DIR / "wechat_scraper_state.json"
-)
-DEFAULT_WECHAT_TEMP_CHUNKS_DIR = (
-    DEFAULT_CHECKPOINT_DATA_DIR / "wechat_temp_chunks"
-)
-DEFAULT_IMPORT_CHECKPOINT_FILE = (
-    DEFAULT_CHECKPOINT_DATA_DIR / "import_knowledge_base.json"
-)
-DEFAULT_PIPELINE_REPORTS_DIR = DEFAULT_REPORTS_DATA_DIR / "pipelines"
-DEFAULT_WECHAT_RAW_CURRENT = (
-    DEFAULT_CURRENT_DATA_DIR / "wechat_articles_all.json"
-)
-DEFAULT_KNOWLEDGE_BASE_CURRENT = (
-    DEFAULT_CURRENT_DATA_DIR / "wechat_articles_processed.json"
-)
-LEGACY_WECHAT_RAW_INPUT = DEFAULT_DATA_DIR / "wechat_articles_all.json"
-LEGACY_KNOWLEDGE_BASE_INPUT = (
-    DEFAULT_DATA_DIR / "wechat_articles_processed.json"
-)
-DEFAULT_WECHAT_RAW_INPUT = DEFAULT_WECHAT_RAW_CURRENT
-DEFAULT_KNOWLEDGE_BASE_INPUT = (
-    DEFAULT_KNOWLEDGE_BASE_CURRENT
-)
 
+# Logical storage keys (``/``-separated, relative to the storage root).
+WECHAT_CHECKPOINT_KEY = "checkpoints/wechat_scraper_state.json"
+WECHAT_TEMP_CHUNKS_PREFIX = "checkpoints/wechat_temp_chunks"
+WECHAT_RAW_DIR_KEY = "raw/wechat"
+WECHAT_RAW_CURRENT_KEY = "current/wechat_articles_all.json"
+KNOWLEDGE_BASE_PROCESSED_DIR_KEY = "processed/knowledge_base"
+KNOWLEDGE_BASE_CURRENT_KEY = "current/wechat_articles_processed.json"
+IMPORT_CHECKPOINT_KEY = "checkpoints/import_knowledge_base.json"
+PIPELINE_REPORTS_PREFIX = "reports/pipelines"
 
-def import_checkpoint_file_for(input_file: Path) -> Path:
-    if input_file == DEFAULT_KNOWLEDGE_BASE_INPUT:
-        return DEFAULT_IMPORT_CHECKPOINT_FILE
-    if input_file.parent.name == "current":
-        return (
-            input_file.parent.parent
-            / "checkpoints"
-            / "import_knowledge_base.json"
-        )
-    return input_file.parent / "checkpoints" / "import_knowledge_base.json"
+# Default logical keys for CLI inputs.
+DEFAULT_WECHAT_RAW_INPUT_KEY = WECHAT_RAW_CURRENT_KEY
+DEFAULT_KNOWLEDGE_BASE_INPUT_KEY = KNOWLEDGE_BASE_CURRENT_KEY

--- a/pipelines/shared/reports.py
+++ b/pipelines/shared/reports.py
@@ -1,20 +1,13 @@
 import json
-from pathlib import Path
 from typing import Any
+
+from pipelines.shared.storage import Storage
 
 
 def write_json_report(
-    report_file: Path,
+    storage: Storage,
+    key: str,
     payload: dict[str, Any],
-) -> Path:
-    report_file.parent.mkdir(parents=True, exist_ok=True)
-    temporary_file = report_file.with_suffix(
-        f"{report_file.suffix}.tmp"
-    )
-
-    with temporary_file.open("w", encoding="utf-8") as file:
-        json.dump(payload, file, ensure_ascii=False, indent=2, default=str)
-        file.write("\n")
-
-    temporary_file.replace(report_file)
-    return report_file
+) -> None:
+    document = json.dumps(payload, ensure_ascii=False, indent=2, default=str)
+    storage.write(key, f"{document}\n".encode("utf-8"))

--- a/pipelines/shared/storage/__init__.py
+++ b/pipelines/shared/storage/__init__.py
@@ -1,0 +1,9 @@
+from pipelines.shared.storage.base import Storage, StorageNotFoundError
+from pipelines.shared.storage.local import LocalStorage
+
+
+__all__ = [
+    "LocalStorage",
+    "Storage",
+    "StorageNotFoundError",
+]

--- a/pipelines/shared/storage/base.py
+++ b/pipelines/shared/storage/base.py
@@ -1,0 +1,52 @@
+"""Storage abstraction for pipeline artifacts.
+
+Pipeline stages read and write artifacts -- raw/processed data, checkpoints and
+reports -- through this small, transport-neutral interface. The same stage code
+can then run against the local filesystem during development and against an
+object store (for example Amazon S3) in the cloud, by swapping the ``Storage``
+implementation without touching stage code.
+
+Keys are ``/``-separated strings, for example ``"reports/pipelines/import.json"``.
+A key is a *location name*, not a filesystem path: each backend maps keys onto
+its own storage layout.
+"""
+
+from typing import Protocol, runtime_checkable
+
+
+class StorageNotFoundError(KeyError):
+    """Raised by ``Storage.read`` when the requested key does not exist."""
+
+
+@runtime_checkable
+class Storage(Protocol):
+    def write(self, key: str, data: bytes) -> None:
+        """Store ``data`` under ``key``, replacing any existing value.
+
+        The write is atomic: a reader either sees the previous value or the new
+        one, never a partially written artifact.
+        """
+        ...
+
+    def read(self, key: str) -> bytes:
+        """Return the bytes stored under ``key``.
+
+        Raises ``StorageNotFoundError`` if the key does not exist.
+        """
+        ...
+
+    def exists(self, key: str) -> bool:
+        """Return whether ``key`` currently holds a value."""
+        ...
+
+    def list(self, prefix: str) -> list[str]:
+        """Return all keys that start with ``prefix``, sorted."""
+        ...
+
+    def delete(self, key: str) -> None:
+        """Delete ``key``. A missing key is not an error."""
+        ...
+
+    def delete_prefix(self, prefix: str) -> None:
+        """Delete every key that starts with ``prefix``."""
+        ...

--- a/pipelines/shared/storage/local.py
+++ b/pipelines/shared/storage/local.py
@@ -1,0 +1,68 @@
+"""Filesystem-backed :class:`Storage` implementation for local development."""
+
+import shutil
+from pathlib import Path
+
+from pipelines.shared.storage.base import StorageNotFoundError
+
+
+class LocalStorage:
+    """Store artifacts on the local filesystem under ``base_dir``.
+
+    A key is resolved relative to ``base_dir``, so the on-disk layout is
+    identical to the pre-abstraction pipeline: with ``base_dir`` pointing at
+    ``data/``, the key ``"reports/pipelines/import.json"`` maps to
+    ``data/reports/pipelines/import.json``.
+
+    Writes go through a temporary file and an atomic rename, so a crash
+    mid-write never leaves a partially written artifact behind. Temporary
+    ``.tmp`` files are ignored by ``list`` and ``delete_prefix``.
+    """
+
+    def __init__(self, base_dir: Path):
+        self.base_dir = base_dir
+
+    def _path(self, key: str) -> Path:
+        return self.base_dir / key
+
+    def write(self, key: str, data: bytes) -> None:
+        path = self._path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_file = path.with_suffix(f"{path.suffix}.tmp")
+        temporary_file.write_bytes(data)
+        temporary_file.replace(path)
+
+    def read(self, key: str) -> bytes:
+        try:
+            return self._path(key).read_bytes()
+        except FileNotFoundError as error:
+            raise StorageNotFoundError(key) from error
+
+    def exists(self, key: str) -> bool:
+        return self._path(key).is_file()
+
+    def list(self, prefix: str) -> list[str]:
+        target = self._path(prefix)
+        search_root = target if target.is_dir() else target.parent
+        if not search_root.exists():
+            return []
+
+        keys = []
+        for path in search_root.rglob("*"):
+            if not path.is_file() or path.suffix == ".tmp":
+                continue
+            key = path.relative_to(self.base_dir).as_posix()
+            if key.startswith(prefix):
+                keys.append(key)
+        return sorted(keys)
+
+    def delete(self, key: str) -> None:
+        self._path(key).unlink(missing_ok=True)
+
+    def delete_prefix(self, prefix: str) -> None:
+        target = self._path(prefix)
+        if target.is_dir():
+            shutil.rmtree(target)
+            return
+        for key in self.list(prefix):
+            self._path(key).unlink(missing_ok=True)

--- a/tests/unit/test_import_checkpoint.py
+++ b/tests/unit/test_import_checkpoint.py
@@ -9,6 +9,7 @@ from pipelines.shared.import_checkpoint import (
     build_import_checkpoint_identity,
     fingerprint_records,
 )
+from pipelines.shared.storage import LocalStorage
 
 
 def _identity():
@@ -51,8 +52,10 @@ def test_json_checkpoint_store_round_trip():
     if temp_dir.exists():
         shutil.rmtree(temp_dir)
     temp_dir.mkdir()
-    checkpoint_file = temp_dir / "import_checkpoint.json"
-    store = JsonImportCheckpointStore(checkpoint_file)
+    store = JsonImportCheckpointStore(
+        LocalStorage(temp_dir),
+        "import_checkpoint.json",
+    )
     checkpoint = ImportCheckpoint(
         identity=_identity(),
         next_batch_index=2,
@@ -65,7 +68,7 @@ def test_json_checkpoint_store_round_trip():
         store.save(checkpoint)
 
         assert store.load() == checkpoint
-        assert not checkpoint_file.with_suffix(".json.tmp").exists()
+        assert not (temp_dir / "import_checkpoint.json.tmp").exists()
 
         store.clear()
         assert store.load() is None
@@ -99,7 +102,10 @@ def test_json_checkpoint_store_reads_legacy_inserted_count():
 """,
         encoding="utf-8",
     )
-    store = JsonImportCheckpointStore(checkpoint_file)
+    store = JsonImportCheckpointStore(
+        LocalStorage(temp_dir),
+        "import_checkpoint.json",
+    )
 
     try:
         checkpoint = store.load()

--- a/tests/unit/test_import_knowledge_base.py
+++ b/tests/unit/test_import_knowledge_base.py
@@ -18,6 +18,7 @@ from pipelines.orchestration.import_knowledge_base import (
 from pipelines.shared.import_checkpoint import (
     MemoryImportCheckpointStore,
 )
+from pipelines.shared.storage import LocalStorage
 
 
 DATABASE_URL = "postgresql://test:test@localhost:5432/testdb"
@@ -331,16 +332,19 @@ def test_local_import_loads_file_and_constructs_model(
     loader.load_batch.return_value = 1
     mock_loader_class.return_value.__enter__.return_value = loader
 
+    storage = LocalStorage(temp_dir)
     try:
         result = run_local_import(
+            storage,
             DATABASE_URL,
-            input_file=input_file,
+            input_key="knowledge_base.json",
             model_name="test-model",
             model_revision="revision-123",
         )
         cached_result = run_local_import(
+            storage,
             DATABASE_URL,
-            input_file=input_file,
+            input_key="knowledge_base.json",
             model_name="test-model",
             model_revision="revision-123",
         )

--- a/tests/unit/test_pipeline_cli.py
+++ b/tests/unit/test_pipeline_cli.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import ANY, patch
 
 from pipelines.cli import main
@@ -25,7 +24,7 @@ def test_harvest_wechat_command(mock_run_local_harvest):
     exit_code = main(["harvest-wechat"])
 
     assert exit_code == 0
-    mock_run_local_harvest.assert_called_once_with()
+    mock_run_local_harvest.assert_called_once()
 
 
 @patch(
@@ -47,7 +46,7 @@ def test_transform_wechat_command(mock_process_articles):
     exit_code = main(["transform-wechat"])
 
     assert exit_code == 0
-    mock_process_articles.assert_called_once_with()
+    mock_process_articles.assert_called_once()
 
 
 @patch(
@@ -74,8 +73,8 @@ def test_import_knowledge_base_command(mock_run_local_import):
 
     assert exit_code == 0
     assert (
-        mock_run_local_import.call_args.kwargs["checkpoint_file"]
-        == Path("checkpoint.json")
+        mock_run_local_import.call_args.kwargs["checkpoint_key"]
+        == "checkpoint.json"
     )
     assert mock_run_local_import.call_args.kwargs["reset_checkpoint"] is True
 
@@ -96,10 +95,8 @@ def test_run_wechat_pipeline_command(
         dropped_count=1,
         attempted_import_count=9,
         affected_count=8,
-        raw_output_location="data/wechat_articles_all.json",
-        processed_output_file=Path(
-            "data/wechat_articles_processed.json"
-        ),
+        raw_output_location="raw/wechat/wechat_articles_all.json",
+        processed_output_key="current/wechat_articles_processed.json",
     )
 
     exit_code = main(
@@ -116,6 +113,7 @@ def test_run_wechat_pipeline_command(
         "postgresql://test:test@localhost:5432/testdb"
     )
     mock_run_pipeline.assert_called_once_with(
+        ANY,
         database_url=(
             "postgresql://test:test@localhost:5432/testdb"
         ),

--- a/tests/unit/test_pipeline_paths.py
+++ b/tests/unit/test_pipeline_paths.py
@@ -1,39 +1,17 @@
-from pathlib import Path
-
 from pipelines.shared.paths import (
-    DEFAULT_IMPORT_CHECKPOINT_FILE,
-    DEFAULT_KNOWLEDGE_BASE_INPUT,
-    DEFAULT_PIPELINE_REPORTS_DIR,
-    DEFAULT_WECHAT_CHECKPOINT_FILE,
-    DEFAULT_WECHAT_TEMP_CHUNKS_DIR,
-    import_checkpoint_file_for,
+    DEFAULT_KNOWLEDGE_BASE_INPUT_KEY,
+    IMPORT_CHECKPOINT_KEY,
+    PIPELINE_REPORTS_PREFIX,
+    WECHAT_CHECKPOINT_KEY,
+    WECHAT_TEMP_CHUNKS_PREFIX,
 )
 
 
 def test_default_pipeline_artifacts_use_production_data_layout():
-    assert "data/current" in DEFAULT_KNOWLEDGE_BASE_INPUT.as_posix()
-    assert "data/checkpoints" in DEFAULT_IMPORT_CHECKPOINT_FILE.as_posix()
-    assert "data/checkpoints" in DEFAULT_WECHAT_CHECKPOINT_FILE.as_posix()
-    assert "data/checkpoints" in DEFAULT_WECHAT_TEMP_CHUNKS_DIR.as_posix()
-    assert "data/reports/pipelines" in DEFAULT_PIPELINE_REPORTS_DIR.as_posix()
-
-
-def test_import_checkpoint_defaults_to_data_checkpoints_for_current_input():
-    input_file = Path("example-data/current/wechat_articles_processed.json")
-
-    assert import_checkpoint_file_for(input_file) == (
-        Path("example-data")
-        / "checkpoints"
-        / "import_knowledge_base.json"
+    assert DEFAULT_KNOWLEDGE_BASE_INPUT_KEY == (
+        "current/wechat_articles_processed.json"
     )
-
-
-def test_import_checkpoint_stays_near_custom_non_current_input():
-    input_file = Path("example-data/custom/records.json")
-
-    assert import_checkpoint_file_for(input_file) == (
-        Path("example-data")
-        / "custom"
-        / "checkpoints"
-        / "import_knowledge_base.json"
-    )
+    assert IMPORT_CHECKPOINT_KEY == "checkpoints/import_knowledge_base.json"
+    assert WECHAT_CHECKPOINT_KEY == "checkpoints/wechat_scraper_state.json"
+    assert WECHAT_TEMP_CHUNKS_PREFIX == "checkpoints/wechat_temp_chunks"
+    assert PIPELINE_REPORTS_PREFIX == "reports/pipelines"

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+from pipelines.shared.reports import write_json_report
+from pipelines.shared.storage import LocalStorage
+
+
+def test_write_json_report_stores_payload_under_key(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    write_json_report(storage, "reports/pipelines/run.json", {"status": "ok"})
+
+    assert json.loads(storage.read("reports/pipelines/run.json")) == {
+        "status": "ok"
+    }
+
+
+def test_write_json_report_is_pretty_printed_with_trailing_newline(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    write_json_report(storage, "reports/run.json", {"a": 1})
+
+    assert storage.read("reports/run.json").decode("utf-8") == (
+        "{\n"
+        '  "a": 1\n'
+        "}\n"
+    )
+
+
+def test_write_json_report_keeps_non_ascii_and_serializes_unknown_types(tmp_path: Path):
+    from datetime import date
+
+    storage = LocalStorage(tmp_path)
+
+    write_json_report(
+        storage,
+        "reports/run.json",
+        {"city": "墨尔本", "day": date(2026, 7, 24)},
+    )
+
+    document = storage.read("reports/run.json").decode("utf-8")
+    assert "墨尔本" in document  # ensure_ascii=False keeps CJK readable
+    assert "2026-07-24" in document  # default=str serializes date

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+import pytest
+
+from pipelines.shared.storage import (
+    LocalStorage,
+    Storage,
+    StorageNotFoundError,
+)
+
+
+def test_local_storage_satisfies_storage_protocol(tmp_path: Path):
+    assert isinstance(LocalStorage(tmp_path), Storage)
+
+
+def test_write_then_read_round_trips_bytes(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    storage.write("reports/run.json", b"payload")
+
+    assert storage.read("reports/run.json") == b"payload"
+
+
+def test_write_creates_nested_directories(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    storage.write("checkpoints/wechat/state.json", b"{}")
+
+    assert (tmp_path / "checkpoints" / "wechat" / "state.json").is_file()
+
+
+def test_write_maps_key_onto_base_dir_layout(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    storage.write("reports/pipelines/import.json", b"{}")
+
+    assert (tmp_path / "reports" / "pipelines" / "import.json").read_bytes() == b"{}"
+
+
+def test_write_overwrites_existing_value(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    storage.write("current/articles.json", b"old")
+    storage.write("current/articles.json", b"new")
+
+    assert storage.read("current/articles.json") == b"new"
+
+
+def test_write_leaves_no_temporary_file_behind(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    storage.write("current/articles.json", b"payload")
+
+    assert list(tmp_path.rglob("*.tmp")) == []
+
+
+def test_read_missing_key_raises_storage_not_found(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    with pytest.raises(StorageNotFoundError):
+        storage.read("does/not/exist.json")
+
+
+def test_exists_reflects_presence(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    assert storage.exists("checkpoints/state.json") is False
+    storage.write("checkpoints/state.json", b"{}")
+    assert storage.exists("checkpoints/state.json") is True
+
+
+def test_list_returns_sorted_keys_under_prefix(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+    storage.write("raw/wechat/batch_2.json", b"[]")
+    storage.write("raw/wechat/batch_1.json", b"[]")
+    storage.write("processed/other.json", b"[]")
+
+    assert storage.list("raw/wechat/") == [
+        "raw/wechat/batch_1.json",
+        "raw/wechat/batch_2.json",
+    ]
+
+
+def test_list_ignores_temporary_files(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+    storage.write("raw/batch_1.json", b"[]")
+    (tmp_path / "raw" / "batch_1.json.tmp").write_bytes(b"partial")
+
+    assert storage.list("raw/") == ["raw/batch_1.json"]
+
+
+def test_list_missing_prefix_returns_empty(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    assert storage.list("nothing/here/") == []
+
+
+def test_delete_removes_key(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+    storage.write("checkpoints/state.json", b"{}")
+
+    storage.delete("checkpoints/state.json")
+
+    assert storage.exists("checkpoints/state.json") is False
+
+
+def test_delete_missing_key_is_not_an_error(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+
+    storage.delete("checkpoints/state.json")
+
+
+def test_delete_prefix_removes_whole_subtree(tmp_path: Path):
+    storage = LocalStorage(tmp_path)
+    storage.write("checkpoints/temp/batch_0.json", b"[]")
+    storage.write("checkpoints/temp/batch_1.json", b"[]")
+    storage.write("checkpoints/state.json", b"{}")
+
+    storage.delete_prefix("checkpoints/temp")
+
+    assert storage.list("checkpoints/") == ["checkpoints/state.json"]

--- a/tests/unit/test_validate_knowledge_base.py
+++ b/tests/unit/test_validate_knowledge_base.py
@@ -3,6 +3,7 @@ import shutil
 from pathlib import Path
 
 from pipelines.shared.json_records import load_json_records
+from pipelines.shared.storage import LocalStorage
 from pipelines.validation.knowledge_base_records import validate_records
 
 
@@ -33,7 +34,10 @@ def test_validate_records_accepts_processed_wechat_shape():
             encoding="utf-8",
         )
 
-        records = load_json_records(input_file)
+        records = load_json_records(
+            LocalStorage(temp_dir),
+            "wechat_articles_processed.json",
+        )
 
         assert validate_records(records) == []
     finally:

--- a/tests/unit/test_wechat_pipeline.py
+++ b/tests/unit/test_wechat_pipeline.py
@@ -12,6 +12,7 @@ from pipelines.orchestration.wechat_pipeline import (
     WechatPipelineRunResult,
     run_local_wechat_pipeline,
 )
+from pipelines.shared.storage import LocalStorage
 from pipelines.transform.wechat_articles import (
     WechatTransformResult,
     WechatTransformStats,
@@ -40,6 +41,7 @@ def test_local_pipeline_runs_stages_and_returns_report():
     if data_dir.exists():
         shutil.rmtree(data_dir)
     data_dir.mkdir()
+    storage = LocalStorage(data_dir)
     metadata_loader = MagicMock()
 
     try:
@@ -48,8 +50,7 @@ def test_local_pipeline_runs_stages_and_returns_report():
                 "pipelines.orchestration.wechat_pipeline.run_local_harvest",
                 return_value=HarvestResult(
                     output_location=(
-                        str(data_dir)
-                        + "/raw/wechat/"
+                        "raw/wechat/"
                         "wechat_articles_20260710T010203Z.json"
                     ),
                     articles_written=12,
@@ -82,8 +83,8 @@ def test_local_pipeline_runs_stages_and_returns_report():
                     lambda *args, **kwargs: datetime(*args, **kwargs)
                 )
                 result = run_local_wechat_pipeline(
+                    storage,
                     DATABASE_URL,
-                    data_dir=data_dir,
                     pipeline_run_loader=metadata_loader,
                     run_id="run-123",
                 )
@@ -99,17 +100,8 @@ def test_local_pipeline_runs_stages_and_returns_report():
         )
         shutil.rmtree(data_dir)
 
-    raw_output_location = (
-        str(data_dir)
-        + "/raw/wechat/"
-        "wechat_articles_20260710T010203Z.json"
-    )
-    expected_report_file = (
-        data_dir
-        / "reports"
-        / "pipelines"
-        / "wechat_pipeline_run-123.json"
-    )
+    raw_output_location = "raw/wechat/wechat_articles_20260710T010203Z.json"
+    report_key = "reports/pipelines/wechat_pipeline_run-123.json"
     assert report_payload["status"] == "completed"
     assert report_payload["pipeline"] == "wechat"
     assert report_payload["transformed_count"] == 9
@@ -122,13 +114,11 @@ def test_local_pipeline_runs_stages_and_returns_report():
     completed_metadata = metadata_loader.upsert_run.call_args_list[1].args[0]
     assert completed_metadata.id == "run-123"
     assert completed_metadata.pipeline_name == "wechat"
-    assert completed_metadata.input_path == str(
-        data_dir / "current" / "wechat_articles_all.json"
+    assert completed_metadata.input_path == "current/wechat_articles_all.json"
+    assert completed_metadata.output_path == (
+        "current/wechat_articles_processed.json"
     )
-    assert completed_metadata.output_path == str(
-        data_dir / "current" / "wechat_articles_processed.json"
-    )
-    assert completed_metadata.report_path == str(expected_report_file)
+    assert completed_metadata.report_path == report_key
     assert completed_metadata.record_count == 9
     assert completed_metadata.affected_count == 8
 
@@ -141,36 +131,35 @@ def test_local_pipeline_runs_stages_and_returns_report():
         attempted_import_count=9,
         affected_count=8,
         raw_output_location=raw_output_location,
-        processed_output_file=(
-            data_dir / "current" / "wechat_articles_processed.json"
-        ),
-        report_file=expected_report_file,
+        processed_output_key="current/wechat_articles_processed.json",
+        report_key=report_key,
     )
     assert result.rejected_count == 3
     harvest.assert_called_once_with(
+        storage,
         config=None,
-        data_dir=data_dir,
         run_started_at=datetime(
             2026, 7, 10, 1, 2, 3, tzinfo=timezone.utc
         ),
     )
     transform.assert_called_once_with(
-        input_file=data_dir / "current" / "wechat_articles_all.json",
-        output_file=data_dir / "current" / "wechat_articles_processed.json",
-        data_dir=data_dir,
+        storage,
+        input_key="current/wechat_articles_all.json",
+        output_key="current/wechat_articles_processed.json",
         created_at=None,
         run_started_at=datetime(
             2026, 7, 10, 1, 2, 3, tzinfo=timezone.utc
         ),
     )
     import_records.assert_called_once_with(
-        database_url=DATABASE_URL,
-        input_file=data_dir / "current" / "wechat_articles_processed.json",
+        storage,
+        DATABASE_URL,
+        input_key="current/wechat_articles_processed.json",
         model_name=None,
         model_revision=None,
         table_name=None,
         batch_size=100,
-        checkpoint_file=None,
+        checkpoint_key=None,
         reset_checkpoint=False,
     )
     completed_events = [
@@ -187,6 +176,7 @@ def test_local_pipeline_writes_failure_report():
     if data_dir.exists():
         shutil.rmtree(data_dir)
     data_dir.mkdir()
+    storage = LocalStorage(data_dir)
     metadata_loader = MagicMock()
 
     try:
@@ -213,8 +203,8 @@ def test_local_pipeline_writes_failure_report():
             pytest.raises(ValueError, match="invalid raw data"),
         ):
             run_local_wechat_pipeline(
+                storage,
                 DATABASE_URL,
-                data_dir=data_dir,
                 pipeline_run_loader=metadata_loader,
                 run_id="run-failure",
             )

--- a/tests/unit/test_wechat_process.py
+++ b/tests/unit/test_wechat_process.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 from pipelines.orchestration.transform_wechat import run_local_transform
-from pipelines.orchestration import transform_wechat as transform_module
+from pipelines.shared.storage import LocalStorage
 from pipelines.transform import wechat_articles
 
 clean_text = wechat_articles.clean_text
@@ -149,9 +149,9 @@ def test_local_transform_reads_and_writes_json():
 
     try:
         result = run_local_transform(
-            input_file=input_file,
-            output_file=output_file,
-            data_dir=temp_dir,
+            LocalStorage(temp_dir),
+            input_key="wechat_articles_all.json",
+            output_key="wechat_articles_processed.json",
             created_at=date(2026, 7, 4),
             run_started_at=datetime(
                 2026, 7, 10, 1, 2, 3, tzinfo=timezone.utc
@@ -166,56 +166,5 @@ def test_local_transform_reads_and_writes_json():
         assert processed == result.records
         assert snapshot == result.records
         assert not output_file.with_suffix(".json.tmp").exists()
-    finally:
-        shutil.rmtree(temp_dir)
-
-
-def test_local_transform_falls_back_to_legacy_raw_file(monkeypatch):
-    temp_dir = Path(__file__).parent / ".tmp_wechat_process_legacy"
-    if temp_dir.exists():
-        shutil.rmtree(temp_dir)
-    temp_dir.mkdir()
-
-    current_input = temp_dir / "current" / "wechat_articles_all.json"
-    legacy_input = temp_dir / "wechat_articles_all.json"
-    output_file = temp_dir / "current" / "wechat_articles_processed.json"
-
-    monkeypatch.setattr(
-        transform_module,
-        "DEFAULT_WECHAT_RAW_INPUT",
-        current_input,
-    )
-    monkeypatch.setattr(
-        transform_module,
-        "LEGACY_WECHAT_RAW_INPUT",
-        legacy_input,
-    )
-    try:
-        legacy_input.write_text(
-            json.dumps(
-                [
-                    {
-                        "is_valid_for_rag": True,
-                        "title": "Legacy raw article",
-                        "content": (
-                            "This article is long enough for import. " * 4
-                        ),
-                        "date": "2026-04-10",
-                        "link": "https://example.com/legacy",
-                    }
-                ]
-            ),
-            encoding="utf-8",
-        )
-
-        result = run_local_transform(
-            input_file=current_input,
-            output_file=output_file,
-            data_dir=temp_dir,
-            created_at=date(2026, 7, 4),
-        )
-
-        assert result.stats.output_count == 1
-        assert output_file.exists()
     finally:
         shutil.rmtree(temp_dir)

--- a/tests/unit/test_wechat_scrape.py
+++ b/tests/unit/test_wechat_scrape.py
@@ -73,18 +73,10 @@ def test_local_checkpoint_store_round_trip(test_workspace):
 
 def test_local_article_sink_is_ordered_and_idempotent(test_workspace):
     sink = JsonChunkArticleSink(
-        temp_dir=test_workspace / "temp_chunks",
-        final_file=(
-            test_workspace
-            / "raw"
-            / "wechat"
-            / "wechat_articles_20260710T010203Z.json"
-        ),
-        current_file=(
-            test_workspace
-            / "current"
-            / "wechat_articles_all.json"
-        ),
+        LocalStorage(test_workspace),
+        "checkpoints/wechat_temp_chunks",
+        "raw/wechat/wechat_articles_20260710T010203Z.json",
+        "current/wechat_articles_all.json",
     )
     sink.write_batch(20, [{"title": "old second"}])
     sink.write_batch(0, [{"title": "first"}])
@@ -110,7 +102,8 @@ def test_local_article_sink_is_ordered_and_idempotent(test_workspace):
     assert articles == [{"title": "first"}, {"title": "second"}]
     assert current_articles == articles
     assert output.article_count == 2
-    assert not (test_workspace / "temp_chunks").exists()
+    assert output.location == "raw/wechat/wechat_articles_20260710T010203Z.json"
+    assert not (test_workspace / "checkpoints" / "wechat_temp_chunks").exists()
 
 
 def test_harvester_uses_injected_client_and_memory_storage(config):

--- a/tests/unit/test_wechat_scrape.py
+++ b/tests/unit/test_wechat_scrape.py
@@ -19,6 +19,7 @@ from pipelines.ingestion.wechat.storage import (
     MemoryArticleSink,
     MemoryCheckpointStore,
 )
+from pipelines.shared.storage import LocalStorage
 
 
 @pytest.fixture
@@ -50,8 +51,10 @@ def test_api_key_is_required(monkeypatch):
 
 
 def test_local_checkpoint_store_round_trip(test_workspace):
-    state_file = test_workspace / "scraper_state.json"
-    store = JsonFileCheckpointStore(state_file)
+    store = JsonFileCheckpointStore(
+        LocalStorage(test_workspace),
+        "scraper_state.json",
+    )
     state = HarvestState(
         begin=40,
         total_saved=35,
@@ -62,7 +65,7 @@ def test_local_checkpoint_store_round_trip(test_workspace):
     store.save(state)
 
     assert store.load() == state
-    assert not state_file.with_suffix(".json.tmp").exists()
+    assert not (test_workspace / "scraper_state.json.tmp").exists()
 
     store.clear()
     assert store.load() == HarvestState()


### PR DESCRIPTION
## What & why

Pipeline stages wrote artifacts (raw/processed JSON, checkpoints, reports)
directly to the local `data/` dir. On AWS the pipeline runs as a Fargate
task whose local disk is ephemeral, so it can't be the source of truth.

This PR inserts a small, transport-neutral `Storage` interface between the
stage code and where bytes actually land. All artifacts are addressed by a
logical **key** relative to a single storage root (`data/` locally, an S3
bucket in the cloud). Switching to S3 later is a one-line change at the
entry point — no stage code changes.

Design write-up: [docs/design/storage-abstraction.md](docs/design/storage-abstraction.md).

## What's in it

- **`Storage` interface + `LocalStorage`** (`pipelines/shared/storage/`):
  6 actions — `write / read / exists / list / delete / delete_prefix` —
  keyed by `/`-separated logical names; `LocalStorage` keeps the same
  on-disk layout and atomic-write semantics as before.
- **All local chokepoints migrated** to `(storage, key)`: reports,
  wechat harvest checkpoint, article sink, `json_records`,
  `JsonImportCheckpointStore`.
- **Composition root**: the CLI builds one `LocalStorage` at the entry and
  threads it into every `run_local_*` stage; stages no longer take
  `data_dir` or construct their own storage.
- Path constants in `paths.py` replaced by logical-key constants.

## Breaking changes

- CLI `--input` and `--checkpoint-file` now take a **logical key**
  (e.g. `current/wechat_articles_processed.json`) instead of a filesystem
  path. Debugging external files means placing them under `data/` first.
- Dropped two local-only features: `import_checkpoint_file_for` (checkpoint
  following an arbitrary input path → now fixed
  `checkpoints/import_knowledge_base.json`) and the transform legacy
  raw-file fallback.
- Pipeline run metadata (`input_path` / `output_path` / `report_path`) and
  `WechatPipelineRunResult` fields now carry logical keys
  (`processed_output_key` / `report_key`).

## Testing

- Full unit suite green: **186 passed** (`pytest tests/unit -q`).
- Byte-for-byte artifact output and on-disk locations unchanged;
  existing pgvector integration test untouched.

## Not in scope

- **`S3Storage`** and AWS wiring — deferred to Phase 3 (future_plan.md).
  All local chokepoints are already migrated, so this is just one new
  backend class implementing the same 6 actions, plus flipping the one
  line at the entry.
