### PR TITLE
fix(api): cap chat_history length and item count

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -175,12 +175,12 @@ class HealthResponse(BaseModel):
 
 class ChatMessage(BaseModel):
     role: Literal["user", "assistant"]
-    content: str = Field(min_length=1)
+    content: str = Field(min_length=1, max_length=4_000)
 
 
 class ChatRequest(BaseModel):
     message: str = Field(min_length=1, max_length=10_000)
-    chat_history: list[ChatMessage] = Field(default_factory=list)
+    chat_history: list[ChatMessage] = Field(default_factory=list, max_length=20)
     top_k: int | None = Field(default=None, ge=1, le=50)
     rerank_top_k: int | None = Field(default=None, ge=1, le=50)
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -211,6 +211,58 @@ def test_chat_rejects_an_empty_message():
     assert response.status_code == 422
 
 
+def test_chat_rejects_a_chat_history_message_over_the_length_cap():
+    response = client().post(
+        "/chat",
+        json={
+            "message": "How do I enrol?",
+            "chat_history": [{"role": "user", "content": "x" * 4_001}],
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_chat_accepts_a_chat_history_message_at_the_length_cap():
+    response = client().post(
+        "/chat",
+        json={
+            "message": "How do I enrol?",
+            "chat_history": [{"role": "user", "content": "x" * 4_000}],
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_chat_rejects_chat_history_over_the_item_count_cap():
+    response = client().post(
+        "/chat",
+        json={
+            "message": "How do I enrol?",
+            "chat_history": [
+                {"role": "user", "content": "hi"} for _ in range(21)
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_chat_accepts_chat_history_at_the_item_count_cap():
+    response = client().post(
+        "/chat",
+        json={
+            "message": "How do I enrol?",
+            "chat_history": [
+                {"role": "user", "content": "hi"} for _ in range(20)
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+
+
 @pytest.mark.parametrize("provided_api_key", [None, "wrong-key"])
 def test_chat_rejects_invalid_or_missing_api_key(
     monkeypatch,


### PR DESCRIPTION
message already had a 10k char cap, but ChatMessage.content and the number of chat_history entries were unbounded. Both are forwarded as-is to OpenAI, so a single request could carry unbounded cost and enough room to forge a fake assistant turn.

Cap content at 4,000 chars and chat_history at 20 entries; FastAPI returns 422 once either limit is exceeded.

Closes CSS-6