### PR TITLE
feat(api)!: add /v1 prefix to the chat endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -211,7 +211,7 @@ def status(
     return get_system_status().to_dict()
 
 
-@app.post("/chat", response_model=ChatResponse, tags=["chat"])
+@app.post("/v1/chat", response_model=ChatResponse, tags=["chat"])
 @limiter.limit(chat_rate_limit)
 def chat(
     request: Request,  # required by slowapi (looked up by this exact name)

--- a/ops/smoke_test_api.py
+++ b/ops/smoke_test_api.py
@@ -85,7 +85,7 @@ def smoke_test_api(
 
     chat = request_json(
         "POST",
-        f"{base_url}/chat",
+        f"{base_url}/v1/chat",
         payload={
             "message": message,
             "top_k": top_k,
@@ -120,19 +120,19 @@ def main() -> int:
     parser.add_argument(
         "--message",
         default="墨尔本 校招",
-        help="Message to send to POST /chat.",
+        help="Message to send to POST /v1/chat.",
     )
     parser.add_argument(
         "--top-k",
         type=int,
         default=3,
-        help="Retriever top_k for /chat.",
+        help="Retriever top_k for /v1/chat.",
     )
     parser.add_argument(
         "--rerank-top-k",
         type=int,
         default=3,
-        help="Reranker top_k for /chat.",
+        help="Reranker top_k for /v1/chat.",
     )
     parser.add_argument(
         "--health-only",
@@ -142,7 +142,7 @@ def main() -> int:
     parser.add_argument(
         "--ready-only",
         action="store_true",
-        help="Check GET /health and GET /ready without calling /chat.",
+        help="Check GET /health and GET /ready without calling /v1/chat.",
     )
     parser.add_argument(
         "--api-key",

--- a/tests/integration/test_api_chat_integration.py
+++ b/tests/integration/test_api_chat_integration.py
@@ -109,7 +109,7 @@ def real_stack_client(test_database_url, monkeypatch):
 
 def test_chat_end_to_end_over_real_stack(real_stack_client):
     response = real_stack_client.post(
-        "/chat",
+        "/v1/chat",
         headers={"X-API-Key": API_KEY},
         json={"message": "How do I apply for special consideration?"},
     )
@@ -133,12 +133,12 @@ def test_rate_limit_429_still_carries_middleware_headers(
     monkeypatch.setattr(settings, "CHAT_RATE_LIMIT", "1/minute")
 
     first = real_stack_client.post(
-        "/chat",
+        "/v1/chat",
         headers={"X-API-Key": API_KEY},
         json={"message": "How do I apply for special consideration?"},
     )
     second = real_stack_client.post(
-        "/chat",
+        "/v1/chat",
         headers={"X-API-Key": API_KEY},
         json={"message": "How do I apply for special consideration?"},
     )

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -189,7 +189,7 @@ def test_status_reports_readiness_and_pipeline_metadata(monkeypatch):
 
 def test_chat_returns_answer_and_sources():
     response = client().post(
-        "/chat",
+        "/v1/chat",
         json={
             "message": "How do I enrol?",
             "chat_history": [{"role": "user", "content": "Hello"}],
@@ -206,7 +206,7 @@ def test_chat_returns_answer_and_sources():
 
 
 def test_chat_rejects_an_empty_message():
-    response = client().post("/chat", json={"message": ""})
+    response = client().post("/v1/chat", json={"message": ""})
 
     assert response.status_code == 422
 
@@ -225,7 +225,7 @@ def test_chat_rejects_invalid_or_missing_api_key(
     )
 
     response = TestClient(app).post(
-        "/chat",
+        "/v1/chat",
         headers=headers,
         json={"message": "How do I enrol?"},
     )
@@ -239,7 +239,7 @@ def test_chat_returns_503_when_api_key_is_not_configured(monkeypatch):
     app.dependency_overrides[get_rag_orchestrator] = lambda: StubOrchestrator()
 
     response = TestClient(app).post(
-        "/chat",
+        "/v1/chat",
         headers={"X-API-Key": "any-key"},
         json={"message": "How do I enrol?"},
     )
@@ -255,7 +255,7 @@ def test_chat_accepts_configured_api_key(monkeypatch):
     app.dependency_overrides[get_rag_orchestrator] = lambda: StubOrchestrator()
 
     response = TestClient(app).post(
-        "/chat",
+        "/v1/chat",
         headers={"X-API-Key": "expected-key"},
         json={"message": "How do I enrol?"},
     )
@@ -302,7 +302,7 @@ def test_chat_returns_safe_service_errors(
     app.dependency_overrides[require_internal_api_key] = lambda: None
 
     response = TestClient(app).post(
-        "/chat",
+        "/v1/chat",
         json={"message": "How do I enrol?"},
     )
 

--- a/tests/unit/test_api_middleware.py
+++ b/tests/unit/test_api_middleware.py
@@ -125,7 +125,7 @@ def test_access_log_emitted_with_request_metadata(captured_app_logs):
 
 def test_deep_log_carries_same_request_id_as_response(captured_app_logs):
     response = client().post(
-        "/chat",
+        "/v1/chat",
         headers={"X-Request-ID": "trace-me-deeply"},
         json={"message": "How do I enrol?"},
     )
@@ -179,7 +179,7 @@ def test_security_headers_present_on_error():
     )
     app.dependency_overrides[require_internal_api_key] = lambda: None
     response = TestClient(app).post(
-        "/chat",
+        "/v1/chat",
         json={"message": "How do I enrol?"},
     )
 
@@ -190,7 +190,7 @@ def test_security_headers_present_on_error():
 
 def test_cors_preflight_allows_configured_origin():
     response = client().options(
-        "/chat",
+        "/v1/chat",
         headers={
             "Origin": "http://localhost:3000",
             "Access-Control-Request-Method": "POST",
@@ -204,7 +204,7 @@ def test_cors_preflight_allows_configured_origin():
 
 def test_cors_omits_headers_for_unconfigured_origin():
     response = client().options(
-        "/chat",
+        "/v1/chat",
         headers={
             "Origin": "http://evil.example.com",
             "Access-Control-Request-Method": "POST",
@@ -218,9 +218,9 @@ def test_chat_rate_limit_returns_safe_429(monkeypatch):
     monkeypatch.setattr(settings, "CHAT_RATE_LIMIT", "2/minute")
     test_client = client()
 
-    first = test_client.post("/chat", json={"message": "hi"})
-    second = test_client.post("/chat", json={"message": "hi"})
-    third = test_client.post("/chat", json={"message": "hi"})
+    first = test_client.post("/v1/chat", json={"message": "hi"})
+    second = test_client.post("/v1/chat", json={"message": "hi"})
+    third = test_client.post("/v1/chat", json={"message": "hi"})
 
     assert first.status_code == 200
     assert second.status_code == 200
@@ -241,7 +241,7 @@ def test_catch_all_handler_returns_safe_500():
     # raise_server_exceptions=False lets the registered handler produce the
     # response instead of the TestClient re-raising the exception.
     response = TestClient(app, raise_server_exceptions=False).post(
-        "/chat",
+        "/v1/chat",
         json={"message": "How do I enrol?"},
     )
 

--- a/tests/unit/test_api_smoke.py
+++ b/tests/unit/test_api_smoke.py
@@ -42,7 +42,7 @@ def test_smoke_test_api_checks_health_and_chat(monkeypatch):
         ("GET", "http://localhost:8000/ready", None, None, 5),
         (
             "POST",
-            "http://localhost:8000/chat",
+            "http://localhost:8000/v1/chat",
             {
                 "message": "墨尔本 校招",
                 "top_k": 2,


### PR DESCRIPTION
/chat has no live consumers yet -- the frontend (myCSSA) has not integrated it. This is the cheapest possible window to introduce versioning: once a client depends on the response contract, breaking changes (e.g. the doc_id semantics change in CSS-7) require a coordinated dual-deploy. Versioning it now lets /v1 and a future /v2 run side by side while clients migrate at their own pace.

- /chat -> /v1/chat
- ops/smoke_test_api.py and its unit test updated to call /v1/chat
- unit and integration tests updated to the new path
- /health, /ready, /status are unchanged: they serve infra (ALB/ECS health checks), not business clients, so they are not versioned

BREAKING CHANGE: the chat endpoint moved from /chat to /v1/chat. No live clients exist yet, so this ships with zero coordination cost.

Closes CSS-8