### PR TITLE
fix(retriever)!: return a stable doc_id instead of a per-request UUID

### DIFF
--- a/app/services/rag/doc_id.py
+++ b/app/services/rag/doc_id.py
@@ -1,0 +1,48 @@
+"""Derive a stable, source-prefixed doc_id for a knowledge-base row.
+
+The id must be identical every time the same underlying document is
+retrieved -- eval metrics (app/services/rag/eval/*.py) match retrieved
+articles against ground truth by id, and structured retrieval logs
+(see CSS-15) key off it too. A random id per request makes both useless.
+
+Today every row comes from WeChat. The WeChat article URL's last path
+segment is already a stable, unique-enough slug, so it's used directly
+with a `wx_` prefix (e.g. `wx_vGqp2DXA34OE8iHxaSaUFg`). Prefixing leaves
+room for future sources with their own scheme -- e.g. a handbook source
+would use `hb_<course_code>_<year>_<section>` rather than a link-derived
+slug, since handbook entries don't have one.
+
+Any link that isn't a recognised WeChat article URL (or is missing) falls
+back to a short deterministic hash so the system still returns *a* stable
+id instead of raising -- callers should not have to special-case retrieval
+failures just because one row is missing a link.
+"""
+
+import hashlib
+from typing import Optional
+from urllib.parse import urlparse
+
+_WECHAT_HOST = "mp.weixin.qq.com"
+_HASH_LENGTH = 16
+
+
+def derive_doc_id(*, link: Optional[str], text: str) -> str:
+    """Return a stable id for a knowledge-base row.
+
+    `link` is preferred when it's a recognised source URL. `text` (the
+    row's content) is the fallback key when there's no usable link, so a
+    missing link still produces a deterministic id rather than a crash.
+    """
+    if link:
+        parsed = urlparse(link)
+        if parsed.netloc == _WECHAT_HOST:
+            slug = parsed.path.rstrip("/").rsplit("/", 1)[-1]
+            if slug:
+                return f"wx_{slug}"
+        return f"kb_{_digest(link)}"
+
+    return f"kb_{_digest(text)}"
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:_HASH_LENGTH]

--- a/app/services/rag/retriever/pg_retriever.py
+++ b/app/services/rag/retriever/pg_retriever.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from app.core.config import settings, rag_config
 from app.schemas.article import Article
 from app.schemas.search_result import SearchResult
+from app.services.rag.doc_id import derive_doc_id
 from app.services.rag.errors import RetrievalUnavailableError
 from app.services.rag.model_registry import model_registry
 from app.services.rag.retriever.base import BaseRetriever
@@ -147,6 +148,7 @@ class PGVectorRetriever(BaseRetriever):
 
         for rank, row in enumerate(rows, start=1):
             article = Article(
+                id=derive_doc_id(link=row["link"], text=row["content"]),
                 text=row["content"],
                 questions=[row["question_text"]] if row["question_text"] else [],
                 source=row["source"],

--- a/tests/unit/test_doc_id.py
+++ b/tests/unit/test_doc_id.py
@@ -1,0 +1,68 @@
+from app.services.rag.doc_id import derive_doc_id
+
+
+def test_wechat_link_uses_the_article_path_segment_with_a_wx_prefix():
+    doc_id = derive_doc_id(
+        link="https://mp.weixin.qq.com/s/vGqp2DXA34OE8iHxaSaUFg",
+        text="irrelevant for this case",
+    )
+
+    assert doc_id == "wx_vGqp2DXA34OE8iHxaSaUFg"
+
+
+def test_wechat_link_is_stable_across_calls():
+    link = "https://mp.weixin.qq.com/s/vGqp2DXA34OE8iHxaSaUFg"
+
+    first = derive_doc_id(link=link, text="content A")
+    second = derive_doc_id(link=link, text="content B")
+
+    assert first == second == "wx_vGqp2DXA34OE8iHxaSaUFg"
+
+
+def test_different_wechat_links_get_different_ids():
+    first = derive_doc_id(
+        link="https://mp.weixin.qq.com/s/aaaaaaaaaaaaaaaaaaaa",
+        text="same text",
+    )
+    second = derive_doc_id(
+        link="https://mp.weixin.qq.com/s/bbbbbbbbbbbbbbbbbbbb",
+        text="same text",
+    )
+
+    assert first != second
+
+
+def test_non_wechat_link_falls_back_to_a_deterministic_hash():
+    link = "https://example.com/handbook/comp90042"
+
+    first = derive_doc_id(link=link, text="content A")
+    second = derive_doc_id(link=link, text="content B")
+
+    assert first == second
+    assert first.startswith("kb_")
+    assert first != "kb_"
+
+
+def test_missing_link_falls_back_to_a_deterministic_hash_of_the_text():
+    text = "Student visa application information."
+
+    first = derive_doc_id(link=None, text=text)
+    second = derive_doc_id(link=None, text=text)
+
+    assert first == second
+    assert first.startswith("kb_")
+
+
+def test_missing_link_with_different_text_gets_a_different_id():
+    first = derive_doc_id(link=None, text="Content A")
+    second = derive_doc_id(link=None, text="Content B")
+
+    assert first != second
+
+
+def test_missing_link_does_not_raise():
+    # A row with no link must still produce *some* stable id instead of
+    # blowing up retrieval for the whole request.
+    doc_id = derive_doc_id(link=None, text="fallback content")
+
+    assert doc_id

--- a/tests/unit/test_pg_retriever.py
+++ b/tests/unit/test_pg_retriever.py
@@ -6,6 +6,7 @@ from psycopg2.pool import PoolError
 
 from app.schemas.article import Article
 from app.schemas.search_result import SearchResult
+from app.services.rag.doc_id import derive_doc_id
 from app.services.rag.errors import RetrievalUnavailableError
 from app.services.rag.model_registry import model_registry
 from app.services.rag.retriever.pg_retriever import PGVectorRetriever
@@ -220,10 +221,23 @@ class TestPGVectorRetrieverUnit(unittest.TestCase):
         self.assertEqual(results[0].article.questions, ["How to apply for a student visa?"])
         self.assertEqual(results[0].score, -0.12)
         self.assertEqual(results[0].rank, 1)
+        self.assertEqual(
+            results[0].article.id,
+            derive_doc_id(
+                link="https://example.com/student-visa",
+                text="Student visa application information.",
+            ),
+        )
 
         self.assertEqual(results[1].article.tags, [])
         self.assertEqual(results[1].score, -0.25)
         self.assertEqual(results[1].rank, 2)
+        # This row has no link -- id must still be present and deterministic,
+        # not the random uuid.uuid4() default (see CSS-7).
+        self.assertEqual(
+            results[1].article.id,
+            derive_doc_id(link=None, text="485 visa requirement details."),
+        )
 
         mock_cursor.execute.assert_called_once()
         _, params = mock_cursor.execute.call_args[0]
@@ -239,6 +253,14 @@ class TestPGVectorRetrieverUnit(unittest.TestCase):
         )
         mock_conn.rollback.assert_called_once_with()
         mock_pool.putconn.assert_called_once_with(mock_conn, close=False)
+
+        # Same query, second call: ids must be identical to the first call so
+        # eval metrics and logging can key off them (see CSS-7).
+        second_call_results = retriever.search("student visa")
+        self.assertEqual(
+            [r.article.id for r in results],
+            [r.article.id for r in second_call_results],
+        )
 
     @patch("app.services.rag.retriever.pg_retriever.SentenceTransformer")
     @patch("app.services.rag.retriever.pg_retriever.ThreadedConnectionPool")


### PR DESCRIPTION
Article.id fell back to uuid.uuid4() because pg_retriever built every Article without passing id at all. Same document, different id on every retrieval -- eval metrics compare retrieved ids against ground-truth ids, so they were structurally guaranteed to read 0 regardless of retrieval quality. Any id returned to a future frontend client would be equally useless to persist.

Add app/services/rag/doc_id.py: derives a source-prefixed id from the row's link (wx_<slug> for WeChat articles, the only source today), with a deterministic hash fallback for a missing/unrecognised link so a row without one still gets a stable id instead of crashing retrieval. The prefix leaves room for a future handbook source (hb_...) without another id-scheme migration.

pg_retriever.py now passes this derived id when constructing each Article. Article's own random default is left in place for callers that build synthetic Articles directly (tests, eval fixtures) -- this fix is scoped to what the retriever returns.

BREAKING CHANGE: sources[].article.id in the /chat response is now a stable, source-derived string instead of a random UUID. No live client persists this value yet, so there's nothing to migrate, but any future frontend work should not assume the old random-per-request shape.

Closes CSS-7